### PR TITLE
blog: add a draft blog to announce nx-plugins project

### DIFF
--- a/docs/nx-playwright-blog.md
+++ b/docs/nx-playwright-blog.md
@@ -1,0 +1,29 @@
+## Announcing Nx-plugin open-source project
+
+Today, we are excited to announce an open-source project called [Nx-plugins](https://github.com/marksandspencer/nx-plugins).
+
+### Introduction
+
+Nx-Plugin is a [Nx](https://nx.dev/) mono repo which consists of plugins which supports the Nx eco-system.
+
+Our plugins so far include:
+
+- **nx-playwright** - An [NX plugin](https://nx.dev/packages/nx-plugin) to add support to an NX monorepo for playwright testing using a native runner.
+
+### Why Open Source?
+
+Adoption for Nx as a mono repo build tool has significantly increased over time. However, there is often some extra configuration work required in order to use external libraries/tools.
+
+While working on an internal project where we were using Playwright for end-to-end testing, some manual configuration was required to integrate Playwright with Nx.
+
+The team within M&S has come up with an internal project to create a plugin which simplifies integration of Nx with Playwright.
+
+With a successful implementation of the nx-plugins project, the team at M&S decided to open-source it to allow the community to benefit from it and contribute to it.
+
+### Licensing
+
+Our project is published under the MIT License.
+
+### Join Us
+
+We appreciate all input from the community. Please share any feedback or questions via GitHub [issues](https://github.com/marksandspencer/nx-plugins/issues). Your support will help to shape the project to meet community needs.

--- a/docs/nx-playwright-blog.md
+++ b/docs/nx-playwright-blog.md
@@ -26,4 +26,7 @@ Our project is published under the MIT License.
 
 ### Join Us
 
-We appreciate all input from the community. Please share any feedback or questions via GitHub [issues](https://github.com/marksandspencer/nx-plugins/issues). Your support will help to shape the project to meet community needs.
+We appreciate all input and contribution from the community.  
+Please share any feedback or questions via GitHub [issues](https://github.com/marksandspencer/nx-plugins/issues).  
+To contribute please check our contribution guideline [here](https://github.com/marksandspencer/nx-plugins/blob/main/CONTRIBUTING.md).  
+Your support will help to shape the project to meet community needs.


### PR DESCRIPTION
Co-authored-by: Farhan Patwary <patwary.farhan87@gmail.com>

## Problem

<sup>A draft version of the blog about the announcement of the open-source project nx-plugins. Once the content of the blog will be finalized then we will post it to an appropriate platform (which is yet to be identified) </sup>

## Solution

<sup>(What has changed, reasons and any additional resources)</sup>

### Useful documentation

- [Contributing guidelines](https://github.com/marksandspencer/nx-plugins/CONTRIBUTING.md)
