### PR TITLE
Add 'ts-check' target to generated project.json in nx-playwright

### DIFF
--- a/packages/nx-playwright/package.json
+++ b/packages/nx-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mands/nx-playwright",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "license": "MIT",
   "publishConfig": {
     "registry": "https://registry.npmjs.org"

--- a/packages/nx-playwright/package.json
+++ b/packages/nx-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mands/nx-playwright",
-  "version": "0.0.19",
+  "version": "0.1.0",
   "license": "MIT",
   "publishConfig": {
     "registry": "https://registry.npmjs.org"

--- a/packages/nx-playwright/src/generators/project/generator.spec.ts
+++ b/packages/nx-playwright/src/generators/project/generator.spec.ts
@@ -1,5 +1,55 @@
+import type { Tree } from '@nrwl/devkit';
+import { Linter } from '@nrwl/linter';
+import { FsTree } from 'nx/src/generators/tree';
+import generator from './generator';
+
 describe('nx-playwright generator', () => {
-  it('noop', async () => {
-    expect(true).toBe(true);
+  it('generates correct project.json', async () => {
+    const host: Tree = new FsTree('.', true);
+    const generate = await generator(host, {
+      name: 'test-generator',
+      linter: Linter.EsLint,
+      project: 'test-project',
+    });
+    await generate();
+    const projectJsonString = host.read('e2e/test-generator/project.json').toString();
+    const projectJson = JSON.parse(projectJsonString);
+
+    expect(projectJson).toEqual({
+      $schema: '../../node_modules/nx/schemas/project-schema.json',
+      sourceRoot: 'e2e/test-generator/src',
+      projectType: 'application',
+      targets: {
+        e2e: {
+          executor: '@mands/nx-playwright:playwright-executor',
+          options: {
+            e2eFolder: 'e2e/test-generator',
+            devServerTarget: 'test-project:serve',
+          },
+          configurations: {
+            production: {
+              devServerTarget: 'test-project:serve:production',
+            },
+          },
+        },
+        'ts-check': {
+          executor: '@nrwl/workspace:run-commands',
+          options: {
+            commands: [
+              {
+                command: `yarn tsc --build apps/test-project/tsconfig.json`,
+              },
+            ],
+          },
+        },
+        lint: {
+          executor: '@nrwl/linter:eslint',
+          outputs: ['{options.outputFile}'],
+          options: { lintFilePatterns: ['e2e/test-generator/**/*.{ts,tsx,js,jsx}'] },
+        },
+      },
+      tags: [],
+      implicitDependencies: ['test-project'],
+    });
   });
 });

--- a/packages/nx-playwright/src/generators/project/generator.ts
+++ b/packages/nx-playwright/src/generators/project/generator.ts
@@ -35,6 +35,16 @@ export default async function (host: Tree, options: NxPlaywrightGeneratorSchema)
           },
         },
       },
+      'ts-check': {
+        executor: '@nrwl/workspace:run-commands',
+        options: {
+          commands: [
+            {
+              command: `yarn tsc --build apps/${options.project}/tsconfig.json`,
+            },
+          ],
+        },
+      },
     },
     tags: normalizedOptions.parsedTags,
     implicitDependencies: options.project ? [options.project] : undefined,


### PR DESCRIPTION
## Problem

When using the `@mands/nx-playwright` generator, the generated `project.json` file does not contain a `ts-check` target.

## Solution

Add a `ts-check` target to the generated `project.json` file.

### Useful documentation


