### PR TITLE
Add additional parameters

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mands/nx-plugins",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Nx plugins by M&S engineering",
   "license": "MIT",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mands/nx-plugins",
-  "version": "0.1.2",
+  "version": "0.1.0",
   "description": "Nx plugins by M&S engineering",
   "license": "MIT",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mands/nx-plugins",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Nx plugins by M&S engineering",
   "license": "MIT",
   "private": false,

--- a/packages/nx-playwright/README.md
+++ b/packages/nx-playwright/README.md
@@ -17,6 +17,18 @@ yarn playwright install --with-deps
 yarn nx e2e <APP-NAME>-e2e
 ```
 
+## Execution Flags
+
+`nx-playwright` has some flags that you can utilize at execution time
+
+- `--browser=BROWSER_TYPE`: allowed browser types being `chromium`, `firefox` or `webkit` (or an `all` type to execute against all 3 types)
+- `--format=FORMAT_TYPE`: this allows values such as `json` or `html`
+- `--headed`: launches the browsers in non-headless mode
+- `--skipServe`: skips the execution of a devServer
+- `--timeout=TIMEOUT_IN_MS`: adds a timeout for your tests
+
+These flags align with the standard [playwright flags](https://playwright.dev/docs/test-cli#reference), as well as the [nx-cypress](https://nx.dev/packages/cypress/executors/cypress#options) ones.
+
 ## Testing this plugin locally
 
 Create a new Nx workspace containing one application. Then run, in the root of this repo:

--- a/packages/nx-playwright/package.json
+++ b/packages/nx-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mands/nx-playwright",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "license": "MIT",
   "publishConfig": {
     "registry": "https://registry.npmjs.org"

--- a/packages/nx-playwright/src/executors/playwright-executor/executor.spec.ts
+++ b/packages/nx-playwright/src/executors/playwright-executor/executor.spec.ts
@@ -27,6 +27,7 @@ describe('executor', () => {
       headed: true,
       browser: 'firefox',
       reporter: 'html',
+      timeout: 1234,
     };
 
     it('concatenates overriding options to playwright command', async () => {
@@ -36,7 +37,7 @@ describe('executor', () => {
       await executor(options, context);
 
       const expected =
-        'yarn playwright test src --config folder/playwright.config.ts --headed --browser=firefox --reporter=html';
+        'yarn playwright test src --config folder/playwright.config.ts --headed --browser=firefox --reporter=html --timeout=1234';
       expect(execCmd).toHaveBeenCalledWith(expected);
     });
   });

--- a/packages/nx-playwright/src/executors/playwright-executor/executor.ts
+++ b/packages/nx-playwright/src/executors/playwright-executor/executor.ts
@@ -8,7 +8,7 @@ function getFlags(options: PlaywrightExecutorSchema): string {
   const headedOption = options.headed === true ? '--headed' : '';
   const browserOption = options.browser?.length ? `--browser=${options.browser}` : '';
   const reporterOption = options.reporter?.length ? `--reporter=${options.reporter}` : '';
-  const timeoutOution = (options.timeout ?? `--timeout=${options.timeout}`) || '';
+  const timeoutOution = options.timeout !== undefined ? `--timeout=${options.timeout}` : '';
 
   const flagStrings = [headedOption, browserOption, reporterOption, timeoutOution].filter(Boolean);
 

--- a/packages/nx-playwright/src/executors/playwright-executor/executor.ts
+++ b/packages/nx-playwright/src/executors/playwright-executor/executor.ts
@@ -11,7 +11,7 @@ function getFlags(options: PlaywrightExecutorSchema): string {
   const timeoutOution = (options.timeout ?? `--timeout=${options.timeout}`) || '';
 
   const flagStrings = [
-    headedOption, browserOption, reporterOption, timeoutOution
+    headedOption, browserOption, reporterOption, timeoutOution,
   ].filter(Boolean);
 
   return flagStrings.join(' ');
@@ -25,10 +25,10 @@ export default async function executor(
 
   const success = await Promise.resolve()
     .then(async () => {
-
+      const flags = getFlags(options);
 
       const { stdout, stderr } = await promisify(exec)(
-        `yarn playwright test src --config ${options.e2eFolder}/playwright.config.ts ${headedOption} ${browserOption} ${reporterOption}`,
+        `yarn playwright test src --config ${options.e2eFolder}/playwright.config.ts ${flags}`,
       );
 
       console.info(`Playwright output ${stdout}`);

--- a/packages/nx-playwright/src/executors/playwright-executor/executor.ts
+++ b/packages/nx-playwright/src/executors/playwright-executor/executor.ts
@@ -4,6 +4,19 @@ import { promisify } from 'util';
 import { startDevServer } from './lib/start-dev-server';
 import { PlaywrightExecutorSchema } from './schema';
 
+function getFlags(options: PlaywrightExecutorSchema): string {
+  const headedOption = options.headed === true ? '--headed' : '';
+  const browserOption = options.browser?.length ? `--browser=${options.browser}` : '';
+  const reporterOption = options.reporter?.length ? `--reporter=${options.reporter}` : '';
+  const timeoutOution = (options.timeout ?? `--timeout=${options.timeout}`) || '';
+
+  const flagStrings = [
+    headedOption, browserOption, reporterOption, timeoutOution
+  ].filter(Boolean);
+
+  return flagStrings.join(' ');
+}
+
 export default async function executor(
   options: PlaywrightExecutorSchema,
   context: ExecutorContext,
@@ -12,9 +25,7 @@ export default async function executor(
 
   const success = await Promise.resolve()
     .then(async () => {
-      const headedOption = options.headed === true ? '--headed' : '';
-      const browserOption = options.browser?.length ? `--browser=${options.browser}` : '';
-      const reporterOption = options.reporter?.length ? `--reporter=${options.reporter}` : '';
+
 
       const { stdout, stderr } = await promisify(exec)(
         `yarn playwright test src --config ${options.e2eFolder}/playwright.config.ts ${headedOption} ${browserOption} ${reporterOption}`,

--- a/packages/nx-playwright/src/executors/playwright-executor/executor.ts
+++ b/packages/nx-playwright/src/executors/playwright-executor/executor.ts
@@ -10,9 +10,7 @@ function getFlags(options: PlaywrightExecutorSchema): string {
   const reporterOption = options.reporter?.length ? `--reporter=${options.reporter}` : '';
   const timeoutOution = (options.timeout ?? `--timeout=${options.timeout}`) || '';
 
-  const flagStrings = [
-    headedOption, browserOption, reporterOption, timeoutOution,
-  ].filter(Boolean);
+  const flagStrings = [headedOption, browserOption, reporterOption, timeoutOution].filter(Boolean);
 
   return flagStrings.join(' ');
 }

--- a/packages/nx-playwright/src/executors/playwright-executor/schema.json
+++ b/packages/nx-playwright/src/executors/playwright-executor/schema.json
@@ -5,6 +5,10 @@
   "description": "Playwright target options for Build Facade",
   "type": "object",
   "properties": {
+    "browser": {
+      "enum": ["all", "chromium", "firefox", "webkit"],
+      "description": "run on specific browser (all for all)"
+    },
     "headed": {
       "type": "boolean",
       "description": "whether to show the browser head"
@@ -13,13 +17,13 @@
       "type": "string",
       "description": "type of output reporter"
     },
-    "browser": {
-      "enum": ["all", "chromium", "firefox", "webkit"],
-      "description": "run on specific browser (all for all)"
-    },
-    "skipServe ": {
+    "skipServe": {
       "type": "boolean",
       "description": "whether to skip starting the server"
+    },
+    "timeout": {
+      "type": "number",
+      "description": "timeout for tests"
     }
   }
 }


### PR DESCRIPTION
## Problem

Needs timeout parameter and cleanup of flags

## Solution

Adds `getFlags`function (to isolate how flags are assembled), and timeout parameter.

The rest of the non-implemented parameters are not in the stock cli and possibly should be removed from the .d.ts file.

Also got around to documenting the flags in the README :).