### PR TITLE
Fix reference to ts config for generated e2e project

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mands/nx-plugins",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Nx plugins by M&S engineering",
   "license": "MIT",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mands/nx-plugins",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Nx plugins by M&S engineering",
   "license": "MIT",
   "private": false,

--- a/packages/nx-playwright/package.json
+++ b/packages/nx-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mands/nx-playwright",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "license": "MIT",
   "publishConfig": {
     "registry": "https://registry.npmjs.org"

--- a/packages/nx-playwright/package.json
+++ b/packages/nx-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mands/nx-playwright",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "license": "MIT",
   "publishConfig": {
     "registry": "https://registry.npmjs.org"

--- a/packages/nx-playwright/src/generators/project/generator.spec.ts
+++ b/packages/nx-playwright/src/generators/project/generator.spec.ts
@@ -37,7 +37,7 @@ describe('nx-playwright generator', () => {
           options: {
             commands: [
               {
-                command: `yarn tsc --build apps/test-project/tsconfig.json`,
+                command: `yarn tsc --build apps/test-project-e2e/tsconfig.json`,
               },
             ],
           },

--- a/packages/nx-playwright/src/generators/project/generator.ts
+++ b/packages/nx-playwright/src/generators/project/generator.ts
@@ -40,7 +40,7 @@ export default async function (host: Tree, options: NxPlaywrightGeneratorSchema)
         options: {
           commands: [
             {
-              command: `yarn tsc --build apps/${options.project}/tsconfig.json`,
+              command: `yarn tsc --build apps/${options.project}-e2e/tsconfig.json`,
             },
           ],
         },


### PR DESCRIPTION
## Problem

Generated e2e project has incorrect reference to TS config

## Solution

Fix reference to ts config for generated e2e project

### Useful documentation

- [Contributing guidelines](https://github.com/marksandspencer/nx-plugins/CONTRIBUTING.md)
