### PR TITLE
Add runner option to playwright

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mands/nx-plugins",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Nx plugins by M&S engineering",
   "license": "MIT",
   "private": false,

--- a/packages/nx-playwright/README.md
+++ b/packages/nx-playwright/README.md
@@ -26,6 +26,7 @@ yarn nx e2e <APP-NAME>-e2e
 - `--headed`: launches the browsers in non-headless mode
 - `--skipServe`: skips the execution of a devServer
 - `--timeout=TIMEOUT_IN_MS`: adds a timeout for your tests
+- `--runner=yarn|npm|pnpm`: package manager to use to run playwright. Defaults to `yarn`
 
 These flags align with the standard [playwright flags](https://playwright.dev/docs/test-cli#reference), as well as the [nx-cypress](https://nx.dev/packages/cypress/executors/cypress#options) ones.
 

--- a/packages/nx-playwright/README.md
+++ b/packages/nx-playwright/README.md
@@ -24,6 +24,7 @@ yarn nx e2e <APP-NAME>-e2e
 - `--browser=BROWSER_TYPE`: allowed browser types being `chromium`, `firefox` or `webkit` (or an `all` type to execute against all 3 types)
 - `--format=FORMAT_TYPE`: this allows values such as `json` or `html`
 - `--headed`: launches the browsers in non-headless mode
+- `--runner`: runner to use for running playwright (npx, pnpn, or yarn). Defaults to yarn.
 - `--skipServe`: skips the execution of a devServer
 - `--timeout=TIMEOUT_IN_MS`: adds a timeout for your tests
 

--- a/packages/nx-playwright/README.md
+++ b/packages/nx-playwright/README.md
@@ -26,7 +26,6 @@ yarn nx e2e <APP-NAME>-e2e
 - `--headed`: launches the browsers in non-headless mode
 - `--skipServe`: skips the execution of a devServer
 - `--timeout=TIMEOUT_IN_MS`: adds a timeout for your tests
-- `--runner=yarn|npm|pnpm`: package manager to use to run playwright. Defaults to `yarn`
 
 These flags align with the standard [playwright flags](https://playwright.dev/docs/test-cli#reference), as well as the [nx-cypress](https://nx.dev/packages/cypress/executors/cypress#options) ones.
 

--- a/packages/nx-playwright/package.json
+++ b/packages/nx-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mands/nx-playwright",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "license": "MIT",
   "publishConfig": {
     "registry": "https://registry.npmjs.org"

--- a/packages/nx-playwright/src/executors/playwright-executor/executor.spec.ts
+++ b/packages/nx-playwright/src/executors/playwright-executor/executor.spec.ts
@@ -21,16 +21,31 @@ console.info = jest.fn().mockReturnValue(null);
 describe('executor', () => {
   beforeEach(jest.resetAllMocks);
 
-  describe('with cli opts', () => {
-    const options: PlaywrightExecutorSchema = {
-      e2eFolder: 'folder',
-      headed: true,
-      browser: 'firefox',
-      reporter: 'html',
-      timeout: 1234,
-    };
+  describe('building runner command', () => {
+    it('uses correct runner', async () => {
+      const options: PlaywrightExecutorSchema = {
+        e2eFolder: 'folder',
+        runner: 'npx',
+      };
+      
+      const execCmd = jest.fn().mockResolvedValueOnce({ stdout: 'passed', stderr: '' });
+      promisify.mockReturnValueOnce(execCmd);
 
+      await executor(options, context);
+
+      const expected = 'npx playwright test src --config folder/playwright.config.ts';
+      expect(execCmd).toHaveBeenCalledWith(expected);
+    });
+    
     it('concatenates overriding options to playwright command', async () => {
+      const options: PlaywrightExecutorSchema = {
+        e2eFolder: 'folder',
+        headed: true,
+        browser: 'firefox',
+        reporter: 'html',
+        timeout: 1234,
+      };
+      
       const execCmd = jest.fn().mockResolvedValueOnce({ stdout: 'passed', stderr: '' });
       promisify.mockReturnValueOnce(execCmd);
 

--- a/packages/nx-playwright/src/executors/playwright-executor/executor.spec.ts
+++ b/packages/nx-playwright/src/executors/playwright-executor/executor.spec.ts
@@ -27,7 +27,7 @@ describe('executor', () => {
         e2eFolder: 'folder',
         runner: 'npx',
       };
-      
+
       const execCmd = jest.fn().mockResolvedValueOnce({ stdout: 'passed', stderr: '' });
       promisify.mockReturnValueOnce(execCmd);
 
@@ -36,7 +36,7 @@ describe('executor', () => {
       const expected = 'npx playwright test src --config folder/playwright.config.ts';
       expect(execCmd).toHaveBeenCalledWith(expected);
     });
-    
+
     it('concatenates overriding options to playwright command', async () => {
       const options: PlaywrightExecutorSchema = {
         e2eFolder: 'folder',
@@ -45,7 +45,7 @@ describe('executor', () => {
         reporter: 'html',
         timeout: 1234,
       };
-      
+
       const execCmd = jest.fn().mockResolvedValueOnce({ stdout: 'passed', stderr: '' });
       promisify.mockReturnValueOnce(execCmd);
 

--- a/packages/nx-playwright/src/executors/playwright-executor/executor.ts
+++ b/packages/nx-playwright/src/executors/playwright-executor/executor.ts
@@ -15,6 +15,12 @@ function getFlags(options: PlaywrightExecutorSchema): string {
   return flagStrings.join(' ');
 }
 
+const runnerCommands = {
+  yarn: 'yarn',
+  npm: 'npx',
+  pnpm: 'pnpm',
+};
+
 export default async function executor(
   options: PlaywrightExecutorSchema,
   context: ExecutorContext,
@@ -24,9 +30,11 @@ export default async function executor(
   const success = await Promise.resolve()
     .then(async () => {
       const flags = getFlags(options);
+      const runnerOption = options.runner !== undefined ? options.runner : 'yarn';
+      const runnerCommand = runnerCommands[runnerOption];
 
       const { stdout, stderr } = await promisify(exec)(
-        `yarn playwright test src --config ${options.e2eFolder}/playwright.config.ts ${flags}`,
+        `${runnerCommand} playwright test src --config ${options.e2eFolder}/playwright.config.ts ${flags}`,
       );
 
       console.info(`Playwright output ${stdout}`);

--- a/packages/nx-playwright/src/executors/playwright-executor/executor.ts
+++ b/packages/nx-playwright/src/executors/playwright-executor/executor.ts
@@ -15,12 +15,6 @@ function getFlags(options: PlaywrightExecutorSchema): string {
   return flagStrings.join(' ');
 }
 
-const runnerCommands = {
-  yarn: 'yarn',
-  npm: 'npx',
-  pnpm: 'pnpm',
-};
-
 export default async function executor(
   options: PlaywrightExecutorSchema,
   context: ExecutorContext,
@@ -30,8 +24,7 @@ export default async function executor(
   const success = await Promise.resolve()
     .then(async () => {
       const flags = getFlags(options);
-      const runnerOption = options.runner !== undefined ? options.runner : 'yarn';
-      const runnerCommand = runnerCommands[runnerOption];
+      const runnerCommand = options.runner ?? 'yarn';
 
       const { stdout, stderr } = await promisify(exec)(
         `${runnerCommand} playwright test src --config ${options.e2eFolder}/playwright.config.ts ${flags}`,

--- a/packages/nx-playwright/src/executors/playwright-executor/executor.ts
+++ b/packages/nx-playwright/src/executors/playwright-executor/executor.ts
@@ -27,7 +27,7 @@ export default async function executor(
       const runnerCommand = options.runner ?? 'yarn';
 
       const { stdout, stderr } = await promisify(exec)(
-        `${runnerCommand} playwright test src --config ${options.e2eFolder}/playwright.config.ts ${flags}`,
+        `${runnerCommand} playwright test src --config ${options.e2eFolder}/playwright.config.ts ${flags}`.trim(),
       );
 
       console.info(`Playwright output ${stdout}`);

--- a/packages/nx-playwright/src/executors/playwright-executor/schema.d.ts
+++ b/packages/nx-playwright/src/executors/playwright-executor/schema.d.ts
@@ -7,7 +7,7 @@ export interface PlaywrightExecutorSchema {
   headed?: boolean;
   reporter?: string;
   browser?: 'chromium' | 'firefox' | 'webkit' | 'all';
-  runner?: 'yarn' | 'npm' | 'pnpm';
+  runner?: 'yarn' | 'npx' | 'pnpm';
   timeout?: number;
   skipServe?: boolean;
 }

--- a/packages/nx-playwright/src/executors/playwright-executor/schema.d.ts
+++ b/packages/nx-playwright/src/executors/playwright-executor/schema.d.ts
@@ -7,6 +7,7 @@ export interface PlaywrightExecutorSchema {
   headed?: boolean;
   reporter?: string;
   browser?: 'chromium' | 'firefox' | 'webkit' | 'all';
+  runner?: 'yarn' | 'npm' | 'pnpm';
   timeout?: number;
   skipServe?: boolean;
 }

--- a/packages/nx-playwright/src/executors/playwright-executor/schema.json
+++ b/packages/nx-playwright/src/executors/playwright-executor/schema.json
@@ -18,8 +18,8 @@
       "description": "type of output reporter"
     },
     "runner": {
-      "enum": ["yarn", "npm", "pnpm"],
-      "description": "package manager to use to run playwright"
+      "enum": ["yarn", "npx", "pnpm"],
+      "description": "runner to use to run playwright"
     },
     "skipServe": {
       "type": "boolean",

--- a/packages/nx-playwright/src/executors/playwright-executor/schema.json
+++ b/packages/nx-playwright/src/executors/playwright-executor/schema.json
@@ -17,6 +17,10 @@
       "type": "string",
       "description": "type of output reporter"
     },
+    "runner": {
+      "enum": ["yarn", "npm", "pnpm"],
+      "description": "package manager to use to run playwright"
+    },
     "skipServe": {
       "type": "boolean",
       "description": "whether to skip starting the server"


### PR DESCRIPTION
This allows using nx-playwright with different package managers
(yarn, npm, or pnpm).

## Problem

Previously the package was hard-coded to use yarn as the runner, so it couldn't be used in projects that used npm/pnpm.

## Solution

`runner` added as an option, defaulting to yarn to avoid breaking existing consumers.