### PR TITLE
Fix minor typo in README

### DIFF
--- a/packages/nx-playwright/README.md
+++ b/packages/nx-playwright/README.md
@@ -24,7 +24,7 @@ yarn nx e2e <APP-NAME>-e2e
 - `--browser=BROWSER_TYPE`: allowed browser types being `chromium`, `firefox` or `webkit` (or an `all` type to execute against all 3 types)
 - `--format=FORMAT_TYPE`: this allows values such as `json` or `html`
 - `--headed`: launches the browsers in non-headless mode
-- `--runner`: runner to use for running playwright (npx, pnpn, or yarn). Defaults to yarn.
+- `--runner`: runner to use for running playwright (`npx`, `pnpm`, or `yarn`). Defaults to `yarn`.
 - `--skipServe`: skips the execution of a devServer
 - `--timeout=TIMEOUT_IN_MS`: adds a timeout for your tests
 


### PR DESCRIPTION
## Problem

`pnpn` instead of `pnpm` in root README.

## Solution

Fix, and wrap in backticks.

### Useful documentation

- [Contributing guidelines](https://github.com/marksandspencer/nx-plugins/CONTRIBUTING.md)
