### PR TITLE
Add packageRunner parameter to generator

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mands/nx-plugins",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Nx plugins by M&S engineering",
   "license": "MIT",
   "private": false,

--- a/packages/nx-playwright/README.md
+++ b/packages/nx-playwright/README.md
@@ -11,7 +11,7 @@ Replacing the placeholders `<PATH-TO-NX-WORKSPACE>` and `<APP-NAME>`:
 
 ```sh
 cd <PATH-TO-NX-WORKSPACE>
-yarn add -D @mands/nx-playwright
+yarn add --dev @mands/nx-playwright
 yarn nx generate @mands/nx-playwright:project <APP-NAME>-e2e --project <APP-NAME>
 yarn playwright install --with-deps
 yarn nx e2e <APP-NAME>-e2e
@@ -24,7 +24,7 @@ yarn nx e2e <APP-NAME>-e2e
 - `--browser=BROWSER_TYPE`: allowed browser types being `chromium`, `firefox` or `webkit` (or an `all` type to execute against all 3 types)
 - `--format=FORMAT_TYPE`: this allows values such as `json` or `html`
 - `--headed`: launches the browsers in non-headless mode
-- `--runner`: runner to use for running playwright (`npx`, `pnpm`, or `yarn`). Defaults to `yarn`.
+- `--packageRunner`: package runner to use for running playwright (`npx`, `pnpm`, or `yarn`). Defaults to `yarn`.
 - `--skipServe`: skips the execution of a devServer
 - `--timeout=TIMEOUT_IN_MS`: adds a timeout for your tests
 

--- a/packages/nx-playwright/package.json
+++ b/packages/nx-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mands/nx-playwright",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "license": "MIT",
   "publishConfig": {
     "registry": "https://registry.npmjs.org"

--- a/packages/nx-playwright/src/executors/playwright-executor/executor.spec.ts
+++ b/packages/nx-playwright/src/executors/playwright-executor/executor.spec.ts
@@ -25,7 +25,7 @@ describe('executor', () => {
     it('uses correct runner', async () => {
       const options: PlaywrightExecutorSchema = {
         e2eFolder: 'folder',
-        runner: 'npx',
+        packageRunner: 'npx',
       };
 
       const execCmd = jest.fn().mockResolvedValueOnce({ stdout: 'passed', stderr: '' });

--- a/packages/nx-playwright/src/executors/playwright-executor/executor.ts
+++ b/packages/nx-playwright/src/executors/playwright-executor/executor.ts
@@ -8,9 +8,9 @@ function getFlags(options: PlaywrightExecutorSchema): string {
   const headedOption = options.headed === true ? '--headed' : '';
   const browserOption = options.browser?.length ? `--browser=${options.browser}` : '';
   const reporterOption = options.reporter?.length ? `--reporter=${options.reporter}` : '';
-  const timeoutOution = options.timeout !== undefined ? `--timeout=${options.timeout}` : '';
+  const timeoutOption = options.timeout !== undefined ? `--timeout=${options.timeout}` : '';
 
-  const flagStrings = [headedOption, browserOption, reporterOption, timeoutOution].filter(Boolean);
+  const flagStrings = [headedOption, browserOption, reporterOption, timeoutOption].filter(Boolean);
 
   return flagStrings.join(' ');
 }
@@ -24,7 +24,7 @@ export default async function executor(
   const success = await Promise.resolve()
     .then(async () => {
       const flags = getFlags(options);
-      const runnerCommand = options.runner ?? 'yarn';
+      const runnerCommand = options.packageRunner ?? 'yarn';
 
       const { stdout, stderr } = await promisify(exec)(
         `${runnerCommand} playwright test src --config ${options.e2eFolder}/playwright.config.ts ${flags}`.trim(),

--- a/packages/nx-playwright/src/executors/playwright-executor/schema.d.ts
+++ b/packages/nx-playwright/src/executors/playwright-executor/schema.d.ts
@@ -1,3 +1,5 @@
+import type { PackageRunner } from '../../types';
+
 export interface PlaywrightExecutorSchema {
   e2eFolder: string;
   devServerTarget?: string;
@@ -7,7 +9,7 @@ export interface PlaywrightExecutorSchema {
   headed?: boolean;
   reporter?: string;
   browser?: 'chromium' | 'firefox' | 'webkit' | 'all';
-  runner?: 'yarn' | 'npx' | 'pnpm';
+  packageRunner?: PackageRunner;
   timeout?: number;
   skipServe?: boolean;
 }

--- a/packages/nx-playwright/src/executors/playwright-executor/schema.json
+++ b/packages/nx-playwright/src/executors/playwright-executor/schema.json
@@ -17,9 +17,10 @@
       "type": "string",
       "description": "type of output reporter"
     },
-    "runner": {
+    "packageRunner": {
       "enum": ["yarn", "npx", "pnpm"],
-      "description": "runner to use to run playwright"
+      "description": "package runner to use to run playwright",
+      "default": "yarn"
     },
     "skipServe": {
       "type": "boolean",

--- a/packages/nx-playwright/src/generators/project/files/src/app.spec.ts__tmpl__
+++ b/packages/nx-playwright/src/generators/project/files/src/app.spec.ts__tmpl__
@@ -3,7 +3,7 @@ import { expect, test } from '@playwright/test';
 import { baseUrl } from './utils';
 
 test('should start page', async ({ page }) => {
-  await page.goto(`${baseUrl}`);
+  await page.goto(baseUrl);
 
   expect(true).toBeTruthy();
 });

--- a/packages/nx-playwright/src/generators/project/generator.spec.ts
+++ b/packages/nx-playwright/src/generators/project/generator.spec.ts
@@ -25,6 +25,7 @@ describe('nx-playwright generator', () => {
           options: {
             e2eFolder: 'e2e/test-generator',
             devServerTarget: 'test-project:serve',
+            packageRunner: 'yarn',
           },
           configurations: {
             production: {
@@ -37,7 +38,7 @@ describe('nx-playwright generator', () => {
           options: {
             commands: [
               {
-                command: `yarn tsc --build --force --verbose apps/test-project-e2e/tsconfig.json`,
+                command: `tsc --build --force --verbose apps/test-project-e2e/tsconfig.json`,
               },
             ],
           },
@@ -52,4 +53,5 @@ describe('nx-playwright generator', () => {
       implicitDependencies: ['test-project'],
     });
   });
+  // TODO: write test for the case where options are overridden
 });

--- a/packages/nx-playwright/src/generators/project/generator.ts
+++ b/packages/nx-playwright/src/generators/project/generator.ts
@@ -28,6 +28,7 @@ export default async function (host: Tree, options: NxPlaywrightGeneratorSchema)
         options: {
           e2eFolder: normalizedOptions.projectRoot,
           devServerTarget: options.project ? `${options.project}:serve` : undefined,
+          packageRunner: options.packageRunner ?? 'yarn',
         },
         configurations: {
           production: {
@@ -40,7 +41,7 @@ export default async function (host: Tree, options: NxPlaywrightGeneratorSchema)
         options: {
           commands: [
             {
-              command: `yarn tsc --build --force --verbose apps/${options.project}-e2e/tsconfig.json`,
+              command: `tsc --build --force --verbose apps/${options.project}-e2e/tsconfig.json`,
             },
           ],
         },

--- a/packages/nx-playwright/src/generators/project/schema.d.ts
+++ b/packages/nx-playwright/src/generators/project/schema.d.ts
@@ -1,4 +1,5 @@
 import { Linter } from '@nrwl/linter';
+import type { PackageRunner } from '../../types';
 
 export interface NxPlaywrightGeneratorSchema {
   project?: string;
@@ -7,4 +8,5 @@ export interface NxPlaywrightGeneratorSchema {
   directory?: string;
   linter: Linter;
   skipFormat?: boolean;
+  packageRunner?: PackageRunner;
 }

--- a/packages/nx-playwright/src/generators/project/schema.json
+++ b/packages/nx-playwright/src/generators/project/schema.json
@@ -35,6 +35,11 @@
       "description": "Skip formatting files",
       "type": "boolean",
       "default": false
+    },
+    "packageRunner": {
+      "enum": ["yarn", "npx", "pnpm"],
+      "description": "package runner to use to run playwright",
+      "default": "yarn"
     }
   },
   "required": ["name"]

--- a/packages/nx-playwright/src/types.ts
+++ b/packages/nx-playwright/src/types.ts
@@ -1,0 +1,1 @@
+export type PackageRunner = 'yarn' | 'npx' | 'pnpm';


### PR DESCRIPTION
## Problem

It's not possible to use a custom package runner when using the generator.

## Solution

- add `packageRunner` parameter to generator
- rename `runner` parameter to `packageRunner` in executor

### Useful documentation

- [Contributing guidelines](https://github.com/marksandspencer/nx-plugins/CONTRIBUTING.md)
