### PR TITLE
Support grep and grepInvert options

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mands/nx-plugins",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Nx plugins by M&S engineering",
   "license": "MIT",
   "private": false,

--- a/packages/nx-playwright/package.json
+++ b/packages/nx-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mands/nx-playwright",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "license": "MIT",
   "publishConfig": {
     "registry": "https://registry.npmjs.org"

--- a/packages/nx-playwright/src/executors/playwright-executor/executor.spec.ts
+++ b/packages/nx-playwright/src/executors/playwright-executor/executor.spec.ts
@@ -44,7 +44,7 @@ describe('executor', () => {
         browser: 'firefox',
         reporter: 'html',
         timeout: 1234,
-        grep: '@tag1'
+        grep: '@tag1',
       };
 
       const execCmd = jest.fn().mockResolvedValueOnce({ stdout: 'passed', stderr: '' });
@@ -60,7 +60,7 @@ describe('executor', () => {
     it('concatenates overriding options to playwright command with grep-invert', async () => {
       const options: PlaywrightExecutorSchema = {
         e2eFolder: 'folder',
-        grepInvert: '@tag1'
+        grepInvert: '@tag1',
       };
 
       const execCmd = jest.fn().mockResolvedValueOnce({ stdout: 'passed', stderr: '' });

--- a/packages/nx-playwright/src/executors/playwright-executor/executor.spec.ts
+++ b/packages/nx-playwright/src/executors/playwright-executor/executor.spec.ts
@@ -44,6 +44,7 @@ describe('executor', () => {
         browser: 'firefox',
         reporter: 'html',
         timeout: 1234,
+        grep: '@tag1'
       };
 
       const execCmd = jest.fn().mockResolvedValueOnce({ stdout: 'passed', stderr: '' });
@@ -52,7 +53,23 @@ describe('executor', () => {
       await executor(options, context);
 
       const expected =
-        'yarn playwright test src --config folder/playwright.config.ts --headed --browser=firefox --reporter=html --timeout=1234';
+        'yarn playwright test src --config folder/playwright.config.ts --headed --browser=firefox --reporter=html --timeout=1234 --grep=@tag1';
+      expect(execCmd).toHaveBeenCalledWith(expected);
+    });
+
+    it('concatenates overriding options to playwright command with grep-invert', async () => {
+      const options: PlaywrightExecutorSchema = {
+        e2eFolder: 'folder',
+        grepInvert: '@tag1'
+      };
+
+      const execCmd = jest.fn().mockResolvedValueOnce({ stdout: 'passed', stderr: '' });
+      promisify.mockReturnValueOnce(execCmd);
+
+      await executor(options, context);
+
+      const expected =
+        'yarn playwright test src --config folder/playwright.config.ts --grep-invert=@tag1';
       expect(execCmd).toHaveBeenCalledWith(expected);
     });
   });

--- a/packages/nx-playwright/src/executors/playwright-executor/executor.ts
+++ b/packages/nx-playwright/src/executors/playwright-executor/executor.ts
@@ -10,8 +10,17 @@ function getFlags(options: PlaywrightExecutorSchema): string {
   const browserOption = options.browser?.length ? `--browser=${options.browser}` : '';
   const reporterOption = options.reporter?.length ? `--reporter=${options.reporter}` : '';
   const timeoutOption = options.timeout !== undefined ? `--timeout=${options.timeout}` : '';
+  const grepOption = options.grep !== undefined ? `--grep=${options.grep}` : '';
+  const grepInvertOption = options.grepInvert !== undefined ? `--grep-invert=${options.grepInvert}` : '';
 
-  const flagStrings = [headedOption, browserOption, reporterOption, timeoutOption].filter(Boolean);
+  const flagStrings = [
+    headedOption,
+    browserOption,
+    reporterOption,
+    timeoutOption,
+    grepOption,
+    grepInvertOption,
+  ].filter(Boolean);
 
   return flagStrings.join(' ');
 }

--- a/packages/nx-playwright/src/executors/playwright-executor/executor.ts
+++ b/packages/nx-playwright/src/executors/playwright-executor/executor.ts
@@ -11,7 +11,8 @@ function getFlags(options: PlaywrightExecutorSchema): string {
   const reporterOption = options.reporter?.length ? `--reporter=${options.reporter}` : '';
   const timeoutOption = options.timeout !== undefined ? `--timeout=${options.timeout}` : '';
   const grepOption = options.grep !== undefined ? `--grep=${options.grep}` : '';
-  const grepInvertOption = options.grepInvert !== undefined ? `--grep-invert=${options.grepInvert}` : '';
+  const grepInvertOption =
+    options.grepInvert !== undefined ? `--grep-invert=${options.grepInvert}` : '';
 
   const flagStrings = [
     headedOption,

--- a/packages/nx-playwright/src/executors/playwright-executor/schema-types.d.ts
+++ b/packages/nx-playwright/src/executors/playwright-executor/schema-types.d.ts
@@ -12,4 +12,6 @@ export interface PlaywrightExecutorSchema {
   packageRunner?: PackageRunner;
   timeout?: number;
   skipServe?: boolean;
+  grep?: string;
+  grepInvert?: string;
 }


### PR DESCRIPTION
## Problem

There was no support for options like grep and grep-invert.

## Solution

Added options to support grep and grep-invert.

### Useful documentation

- [Contributing guidelines](/marksandspencer/nx-plugins/blob/main/CONTRIBUTING.md)
