### PR TITLE
Adding @playwright/test as a peer dependency

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,3 @@
 {
-  "recommendations": [
-    "ms-vscode.vscode-typescript-tslint-plugin",
-    "esbenp.prettier-vscode",
-    "firsttris.vscode-jest-runner"
-  ]
+  "recommendations": ["esbenp.prettier-vscode", "firsttris.vscode-jest-runner"]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,7 @@
 {
-  "recommendations": ["esbenp.prettier-vscode", "firsttris.vscode-jest-runner"]
+  "recommendations": [
+    "esbenp.prettier-vscode",
+    "firsttris.vscode-jest-runner",
+    "dbaeumer.vscode-eslint"
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,7 @@
     "json"
   ],
   "cSpell.words": [
-    "mands"
+    "mands",
+    "nrwl"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,10 @@
     "source.organizeImports": false,
     "source.fixAll.eslint": true
   },
-  "eslint.validate": ["json"]
+  "eslint.validate": [
+    "json"
+  ],
+  "cSpell.words": [
+    "mands"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mands/nx-plugins",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "Nx plugins by M&S engineering",
   "license": "MIT",
   "private": false,

--- a/packages/nx-playwright/package.json
+++ b/packages/nx-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mands/nx-playwright",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "license": "MIT",
   "publishConfig": {
     "registry": "https://registry.npmjs.org"

--- a/packages/nx-playwright/package.json
+++ b/packages/nx-playwright/package.json
@@ -11,5 +11,8 @@
   },
   "main": "index.js",
   "generators": "./generators.json",
-  "executors": "./executors.json"
+  "executors": "./executors.json",
+  "peerDependencies": {
+    "@playwright/test": "^1.25.0"
+  }
 }


### PR DESCRIPTION
## Problem
Playwright dependencies are not a peer dependencies  

## Solution
Adding `@playwright/test` as a peer dependency to ensure that this plugin works and install correct (and tested) versions

### Useful documentation
- [Contributing guidelines](/marksandspencer/nx-plugins/blob/main/CONTRIBUTING.md)
