### PR TITLE
Add dummy smoketest template

### DIFF
--- a/packages/nx-playwright/src/generators/project/files/src/smoketest.spec.ts__tmpl__
+++ b/packages/nx-playwright/src/generators/project/files/src/smoketest.spec.ts__tmpl__
@@ -1,0 +1,7 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Smoke tests for new app', () => {
+  test('default dummy @smoketest', () => {
+    expect(true).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem

Every app (including new apps) now need at least 1 smoketest (tagged with `@smoketest`).

## Solution

Added a dummy smoketest template for new apps.

### Useful documentation

N/A
