### PR TITLE
Basket-192: Make nx-playwright peerDependency on playwright more forgiving

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ We use GitHub to host code, to track issues and feature requests, and to accept 
 
 A pull request is the best way to propose a change to the codebase. We actively welcome your pull requests:
 
-1. Fork the repo and create your branch from `main`
+1. Clone the repo and create your branch from `main`
 2. If you've added code that should be tested, add tests
 3. Manually update the `version` property in the root `package.json`, ensuring you follow [semver](https://semver.org/) conventions when choosing the new version
 4. Do the same in the `package.json` for the package that you have updated in `packages`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ We use GitHub to host code, to track issues and feature requests, and to accept 
 
 A pull request is the best way to propose a change to the codebase. We actively welcome your pull requests:
 
-1. Clone the repo and create your branch from `main`
+1. Fork the repo and create your branch from `main`
 2. If you've added code that should be tested, add tests
 3. Manually update the `version` property in the root `package.json`, ensuring you follow [semver](https://semver.org/) conventions when choosing the new version
 4. Do the same in the `package.json` for the package that you have updated in `packages`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mands/nx-plugins",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "description": "Nx plugins by M&S engineering",
   "license": "MIT",
   "private": false,

--- a/packages/nx-playwright/package.json
+++ b/packages/nx-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mands/nx-playwright",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "license": "MIT",
   "publishConfig": {
     "registry": "https://registry.npmjs.org"

--- a/packages/nx-playwright/package.json
+++ b/packages/nx-playwright/package.json
@@ -13,7 +13,7 @@
   "generators": "./generators.json",
   "executors": "./executors.json",
   "peerDependencies": {
-    "@playwright/test": "1.26.0",
-    "playwright": "1.26.0"
+    "@playwright/test": "^1.26.0",
+    "playwright": "^1.26.0"
   }
 }


### PR DESCRIPTION
## Problem

nx-playwright peerDependency on playwright 1.26.0 is restricted to that single version

## Solution

Make it accept higher minor versions

### Useful documentation

- [Contributing guidelines](/marksandspencer/nx-plugins/blob/main/CONTRIBUTING.md)
