### PR TITLE
Add environment variables option

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mands/nx-plugins",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "description": "Nx plugins by M&S engineering",
   "license": "MIT",
   "private": false,

--- a/packages/nx-playwright/package.json
+++ b/packages/nx-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mands/nx-playwright",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "license": "MIT",
   "publishConfig": {
     "registry": "https://registry.npmjs.org"

--- a/packages/nx-playwright/src/executors/playwright-executor/executor.spec.ts
+++ b/packages/nx-playwright/src/executors/playwright-executor/executor.spec.ts
@@ -39,6 +39,24 @@ describe('executor', () => {
       expect(execCmd).toHaveBeenCalledWith(expected);
     });
 
+    it('add correct environment variables', async () => {
+      const options: PlaywrightExecutorSchema = {
+        e2eFolder: 'folder',
+        environmentVariables: {
+          PLAYWRIGHT_JUNIT_OUTPUT_NAME: 'result.xml',
+        },
+      };
+
+      const execCmd = jest.fn().mockResolvedValueOnce({ stdout: 'passed', stderr: '' });
+      promisify.mockReturnValueOnce(execCmd);
+
+      await executor(options, context);
+
+      const expected =
+        'PLAYWRIGHT_JUNIT_OUTPUT_NAME=result.xml yarn playwright test src --config folder/playwright.config.ts  && echo PLAYWRIGHT_PASS';
+      expect(execCmd).toHaveBeenCalledWith(expected);
+    });
+
     it.each<[string, PlaywrightExecutorSchema]>([
       [
         '--headed --browser=firefox --reporter=html --timeout=1234 --grep=@tag1 && echo PLAYWRIGHT_PASS',

--- a/packages/nx-playwright/src/executors/playwright-executor/executor.ts
+++ b/packages/nx-playwright/src/executors/playwright-executor/executor.ts
@@ -41,9 +41,14 @@ export default async function executor(
       const flags = getFlags(options);
       const runnerCommand =
         options.packageRunner ?? executorSchema.properties.packageRunner.default;
+      const environmentVariables = options.environmentVariables
+        ? Object.keys(options.environmentVariables)
+            .map((key) => `${key}=${options.environmentVariables[key]}`)
+            .join(' ')
+        : '';
 
       const command =
-        `${runnerCommand} playwright test src --config ${options.e2eFolder}/playwright.config.ts ${flags} && echo ${PASS_MARKER}`.trim();
+        `${environmentVariables} ${runnerCommand} playwright test src --config ${options.e2eFolder}/playwright.config.ts ${flags} && echo ${PASS_MARKER}`.trim();
 
       console.debug(`Running ${command}`);
 

--- a/packages/nx-playwright/src/executors/playwright-executor/schema-types.d.ts
+++ b/packages/nx-playwright/src/executors/playwright-executor/schema-types.d.ts
@@ -9,6 +9,7 @@ export interface PlaywrightExecutorSchema {
   headed?: boolean;
   reporter?: string;
   browser?: 'chromium' | 'firefox' | 'webkit' | 'all';
+  environmentVariables?: object;
   packageRunner?: PackageRunner;
   timeout?: number;
   skipServe?: boolean;

--- a/packages/nx-playwright/src/executors/playwright-executor/schema.json
+++ b/packages/nx-playwright/src/executors/playwright-executor/schema.json
@@ -11,6 +11,10 @@
       "enum": ["all", "chromium", "firefox", "webkit"],
       "description": "run on specific browser (all for all)"
     },
+    "environmentVariables": {
+      "type": "object",
+      "description": "environment variables for playwright"
+    },
     "headed": {
       "type": "boolean",
       "description": "whether to show the browser head"


### PR DESCRIPTION
## Problem

Add ability to specify environment variables for Playwright

## Solution

We need to specify different Junit output files between each project.
Either we indicate it in the playwright configuration file or using the environment variable.
Example: PLAYWRIGHT_JUNIT_OUTPUT_NAME

I open this PR to open the topic and see if this solution works for you
