### PR TITLE
allow optional pass with no tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mands/nx-plugins",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "description": "Nx plugins by M&S engineering",
   "license": "MIT",
   "private": false,

--- a/packages/nx-playwright/package.json
+++ b/packages/nx-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mands/nx-playwright",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "license": "MIT",
   "publishConfig": {
     "registry": "https://registry.npmjs.org"

--- a/packages/nx-playwright/src/executors/playwright-executor/executor.spec.ts
+++ b/packages/nx-playwright/src/executors/playwright-executor/executor.spec.ts
@@ -72,6 +72,22 @@ describe('executor', () => {
         'yarn playwright test src --config folder/playwright.config.ts --grep-invert=@tag1';
       expect(execCmd).toHaveBeenCalledWith(expected);
     });
+
+    it('uses optional pass with no tests', async () => {
+      const options: PlaywrightExecutorSchema = {
+        passWithNoTests: true,
+        e2eFolder: 'folder',
+      };
+
+      const execCmd = jest.fn().mockResolvedValueOnce({ stdout: 'passed', stderr: '' });
+      promisify.mockReturnValueOnce(execCmd);
+
+      await executor(options, context);
+
+      const expected =
+        'yarn playwright test src --config folder/playwright.config.ts --pass-with-no-tests';
+      expect(execCmd).toHaveBeenCalledWith(expected);
+    });
   });
 
   describe('playwright execution', () => {

--- a/packages/nx-playwright/src/executors/playwright-executor/executor.spec.ts
+++ b/packages/nx-playwright/src/executors/playwright-executor/executor.spec.ts
@@ -37,56 +37,41 @@ describe('executor', () => {
       expect(execCmd).toHaveBeenCalledWith(expected);
     });
 
-    it('concatenates overriding options to playwright command', async () => {
-      const options: PlaywrightExecutorSchema = {
-        e2eFolder: 'folder',
-        headed: true,
-        browser: 'firefox',
-        reporter: 'html',
-        timeout: 1234,
-        grep: '@tag1',
-      };
-
+    it.each<[string, PlaywrightExecutorSchema]>([
+      [
+        '--headed --browser=firefox --reporter=html --timeout=1234 --grep=@tag1',
+        {
+          e2eFolder: 'folder',
+          headed: true,
+          browser: 'firefox',
+          reporter: 'html',
+          timeout: 1234,
+          grep: '@tag1',
+        },
+      ],
+      [
+        '--grep-invert=@tag1',
+        {
+          e2eFolder: 'folder',
+          grepInvert: '@tag1',
+        },
+      ],
+      [
+        '--pass-with-no-tests',
+        {
+          passWithNoTests: true,
+          e2eFolder: 'folder',
+        },
+      ],
+    ])(`runs playwright with options: %s`, async (expected, options) => {
       const execCmd = jest.fn().mockResolvedValueOnce({ stdout: 'passed', stderr: '' });
       promisify.mockReturnValueOnce(execCmd);
 
       await executor(options, context);
 
-      const expected =
-        'yarn playwright test src --config folder/playwright.config.ts --headed --browser=firefox --reporter=html --timeout=1234 --grep=@tag1';
-      expect(execCmd).toHaveBeenCalledWith(expected);
-    });
-
-    it('concatenates overriding options to playwright command with grep-invert', async () => {
-      const options: PlaywrightExecutorSchema = {
-        e2eFolder: 'folder',
-        grepInvert: '@tag1',
-      };
-
-      const execCmd = jest.fn().mockResolvedValueOnce({ stdout: 'passed', stderr: '' });
-      promisify.mockReturnValueOnce(execCmd);
-
-      await executor(options, context);
-
-      const expected =
-        'yarn playwright test src --config folder/playwright.config.ts --grep-invert=@tag1';
-      expect(execCmd).toHaveBeenCalledWith(expected);
-    });
-
-    it('uses optional pass with no tests', async () => {
-      const options: PlaywrightExecutorSchema = {
-        passWithNoTests: true,
-        e2eFolder: 'folder',
-      };
-
-      const execCmd = jest.fn().mockResolvedValueOnce({ stdout: 'passed', stderr: '' });
-      promisify.mockReturnValueOnce(execCmd);
-
-      await executor(options, context);
-
-      const expected =
-        'yarn playwright test src --config folder/playwright.config.ts --pass-with-no-tests';
-      expect(execCmd).toHaveBeenCalledWith(expected);
+      expect(execCmd).toHaveBeenCalledWith(
+        `yarn playwright test src --config folder/playwright.config.ts ${expected}`.trim(),
+      );
     });
   });
 

--- a/packages/nx-playwright/src/executors/playwright-executor/executor.ts
+++ b/packages/nx-playwright/src/executors/playwright-executor/executor.ts
@@ -7,6 +7,7 @@ import { PlaywrightExecutorSchema } from './schema-types';
 
 function getFlags(options: PlaywrightExecutorSchema): string {
   const headedOption = options.headed === true ? '--headed' : '';
+  const passWithNoTestsOption = options.passWithNoTests === true ? '--pass-with-no-tests' : '';
   const browserOption = options.browser?.length ? `--browser=${options.browser}` : '';
   const reporterOption = options.reporter?.length ? `--reporter=${options.reporter}` : '';
   const timeoutOption = options.timeout !== undefined ? `--timeout=${options.timeout}` : '';
@@ -21,6 +22,7 @@ function getFlags(options: PlaywrightExecutorSchema): string {
     timeoutOption,
     grepOption,
     grepInvertOption,
+    passWithNoTestsOption,
   ].filter(Boolean);
 
   return flagStrings.join(' ');

--- a/packages/nx-playwright/src/executors/playwright-executor/schema-types.d.ts
+++ b/packages/nx-playwright/src/executors/playwright-executor/schema-types.d.ts
@@ -14,4 +14,5 @@ export interface PlaywrightExecutorSchema {
   skipServe?: boolean;
   grep?: string;
   grepInvert?: string;
+  passWithNoTests?: boolean;
 }


### PR DESCRIPTION
## Problem

Some apps may need to pass with no tests when grep or grep inverted are used.

## Solution

Add an optional param `passWithNoTests` to allow for pass with no tests.

### Useful documentation

- [Contributing guidelines](/marksandspencer/nx-plugins/blob/main/CONTRIBUTING.md)
