### PR TITLE
Update playwright dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mands/nx-plugins",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "description": "Nx plugins by M&S engineering",
   "license": "MIT",
   "private": false,

--- a/packages/nx-playwright/package.json
+++ b/packages/nx-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mands/nx-playwright",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "license": "MIT",
   "publishConfig": {
     "registry": "https://registry.npmjs.org"

--- a/packages/nx-playwright/package.json
+++ b/packages/nx-playwright/package.json
@@ -13,7 +13,7 @@
   "generators": "./generators.json",
   "executors": "./executors.json",
   "peerDependencies": {
-    "@playwright/test": "^1.26.0",
-    "playwright": "^1.26.0"
+    "@playwright/test": "^1.29.2",
+    "playwright": "^1.29.2"
   }
 }


### PR DESCRIPTION
## Problem

When installing storybook along with this nx-plugin we need to have matching versions of the playwright dependencies. The versions in this package are outdated.

## Solution

Update packages `@playwright/test` and `playwright` to latest version
