### PR TITLE
Add `path` option to executor

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mands/nx-plugins",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "description": "Nx plugins by M&S engineering",
   "license": "MIT",
   "private": false,

--- a/packages/nx-playwright/README.md
+++ b/packages/nx-playwright/README.md
@@ -38,6 +38,7 @@ yarn nx e2e <APP-NAME>-e2e
 - `--headed`: launches the browser in non-headless mode
 - `--debug`: runs tests in a browser plus another interactive debugger window that you can pause/play tests
 - `--packageRunner`: package runner to use for running playwright (`npx`, `pnpm`, or `yarn`). Defaults to `yarn`
+- `--path`: path to run tests at. Defaults to `src`
 - `--skipServe`: skips the execution of a devServer
 - `--timeout=<number>`: adds a timeout for your tests in milliseconds
 - `--grep=<RegExp|Array<RegExp>>`: filter to only run tests with a title matching one of the patterns

--- a/packages/nx-playwright/package.json
+++ b/packages/nx-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mands/nx-playwright",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "license": "MIT",
   "publishConfig": {
     "registry": "https://registry.npmjs.org"

--- a/packages/nx-playwright/src/executors/playwright-executor/executor.spec.ts
+++ b/packages/nx-playwright/src/executors/playwright-executor/executor.spec.ts
@@ -23,10 +23,11 @@ describe('executor', () => {
   beforeEach(jest.resetAllMocks);
 
   describe('building runner command', () => {
-    it('uses correct runner', async () => {
+    it('uses correct runner and path', async () => {
       const options: PlaywrightExecutorSchema = {
         e2eFolder: 'folder',
         packageRunner: 'npx',
+        path: 'src/tests',
       };
 
       const execCmd = jest.fn().mockResolvedValueOnce({ stdout: 'passed', stderr: '' });
@@ -35,7 +36,7 @@ describe('executor', () => {
       await executor(options, context);
 
       const expected =
-        'npx playwright test src --config folder/playwright.config.ts  && echo PLAYWRIGHT_PASS';
+        'npx playwright test src/tests --config folder/playwright.config.ts  && echo PLAYWRIGHT_PASS';
       expect(execCmd).toHaveBeenCalledWith(expected);
     });
 

--- a/packages/nx-playwright/src/executors/playwright-executor/executor.ts
+++ b/packages/nx-playwright/src/executors/playwright-executor/executor.ts
@@ -41,9 +41,10 @@ export default async function executor(
       const flags = getFlags(options);
       const runnerCommand =
         options.packageRunner ?? executorSchema.properties.packageRunner.default;
+      const path = options.path ?? executorSchema.properties.path.default;
 
       const command =
-        `${runnerCommand} playwright test src --config ${options.e2eFolder}/playwright.config.ts ${flags} && echo ${PASS_MARKER}`.trim();
+        `${runnerCommand} playwright test ${path} --config ${options.e2eFolder}/playwright.config.ts ${flags} && echo ${PASS_MARKER}`.trim();
 
       console.debug(`Running ${command}`);
 

--- a/packages/nx-playwright/src/executors/playwright-executor/schema-types.d.ts
+++ b/packages/nx-playwright/src/executors/playwright-executor/schema-types.d.ts
@@ -2,6 +2,7 @@ import type { PackageRunner } from '../../types';
 
 export interface PlaywrightExecutorSchema {
   e2eFolder: string;
+  path?: string;
   devServerTarget?: string;
   baseUrl?: string;
   slowMo?: number;

--- a/packages/nx-playwright/src/executors/playwright-executor/schema.json
+++ b/packages/nx-playwright/src/executors/playwright-executor/schema.json
@@ -24,6 +24,11 @@
       "description": "package runner to use to run playwright",
       "default": "yarn"
     },
+    "path": {
+      "type": "string",
+      "description": "path to run tests at",
+      "default": "src"
+    },
     "skipServe": {
       "type": "boolean",
       "description": "whether to skip starting the server"

--- a/packages/nx-playwright/src/generators/project/files/tsconfig.e2e.json
+++ b/packages/nx-playwright/src/generators/project/files/tsconfig.e2e.json
@@ -6,5 +6,5 @@
     "allowJs": true,
     "types": ["jest", "node"]
   },
-  "include": ["src/**/*.ts", "src/**/*.js"]
+  "include": ["**/*.ts", "**/*.js"]
 }


### PR DESCRIPTION
## Problem

Want to be able to customise the path the playwright tests run at
For BASKET-253

## Solution

- Add path to executor options
- Switch tsconfig `include` from `src/**/*.ts` => `**/*.ts`, to match all files, not just src
