### PR TITLE
Add `config` option to executor

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mands/nx-plugins",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "description": "Nx plugins by M&S engineering",
   "license": "MIT",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mands/nx-plugins",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "description": "Nx plugins by M&S engineering",
   "license": "MIT",
   "private": false,

--- a/packages/nx-playwright/README.md
+++ b/packages/nx-playwright/README.md
@@ -34,6 +34,7 @@ yarn nx e2e <APP-NAME>-e2e
 `nx-playwright` has some flags that you can utilize at execution time
 
 - `--browser=BROWSER_TYPE`: allowed browser types being `chromium`, `firefox` or `webkit` (or an `all` type to execute against all 3 types)
+- `--config`: configuration file. Defaults to `playwright.config.ts`
 - `--format=FORMAT_TYPE`: this allows values such as `json` or `html`
 - `--headed`: launches the browser in non-headless mode
 - `--debug`: runs tests in a browser plus another interactive debugger window that you can pause/play tests

--- a/packages/nx-playwright/package.json
+++ b/packages/nx-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mands/nx-playwright",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "license": "MIT",
   "publishConfig": {
     "registry": "https://registry.npmjs.org"

--- a/packages/nx-playwright/package.json
+++ b/packages/nx-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mands/nx-playwright",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "license": "MIT",
   "publishConfig": {
     "registry": "https://registry.npmjs.org"

--- a/packages/nx-playwright/src/executors/playwright-executor/executor.spec.ts
+++ b/packages/nx-playwright/src/executors/playwright-executor/executor.spec.ts
@@ -23,11 +23,12 @@ describe('executor', () => {
   beforeEach(jest.resetAllMocks);
 
   describe('building runner command', () => {
-    it('uses correct runner and path', async () => {
+    it('uses correct runner and path and config', async () => {
       const options: PlaywrightExecutorSchema = {
         e2eFolder: 'folder',
         packageRunner: 'npx',
         path: 'src/tests',
+        config: 'config/playwright.config.ts',
       };
 
       const execCmd = jest.fn().mockResolvedValueOnce({ stdout: 'passed', stderr: '' });
@@ -36,7 +37,7 @@ describe('executor', () => {
       await executor(options, context);
 
       const expected =
-        'npx playwright test src/tests --config folder/playwright.config.ts  && echo PLAYWRIGHT_PASS';
+        'npx playwright test src/tests --config folder/config/playwright.config.ts  && echo PLAYWRIGHT_PASS';
       expect(execCmd).toHaveBeenCalledWith(expected);
     });
 

--- a/packages/nx-playwright/src/executors/playwright-executor/executor.ts
+++ b/packages/nx-playwright/src/executors/playwright-executor/executor.ts
@@ -42,9 +42,10 @@ export default async function executor(
       const runnerCommand =
         options.packageRunner ?? executorSchema.properties.packageRunner.default;
       const path = options.path ?? executorSchema.properties.path.default;
+      const config = options.config ?? executorSchema.properties.config.default;
 
       const command =
-        `${runnerCommand} playwright test ${path} --config ${options.e2eFolder}/playwright.config.ts ${flags} && echo ${PASS_MARKER}`.trim();
+        `${runnerCommand} playwright test ${path} --config ${options.e2eFolder}/${config} ${flags} && echo ${PASS_MARKER}`.trim();
 
       console.debug(`Running ${command}`);
 

--- a/packages/nx-playwright/src/executors/playwright-executor/schema-types.d.ts
+++ b/packages/nx-playwright/src/executors/playwright-executor/schema-types.d.ts
@@ -3,6 +3,7 @@ import type { PackageRunner } from '../../types';
 export interface PlaywrightExecutorSchema {
   e2eFolder: string;
   path?: string;
+  config?: string;
   devServerTarget?: string;
   baseUrl?: string;
   slowMo?: number;

--- a/packages/nx-playwright/src/executors/playwright-executor/schema.json
+++ b/packages/nx-playwright/src/executors/playwright-executor/schema.json
@@ -11,6 +11,11 @@
       "enum": ["all", "chromium", "firefox", "webkit"],
       "description": "run on specific browser (all for all)"
     },
+    "config": {
+      "type": "string",
+      "description": "configuration file",
+      "default": "playwright.config.ts"
+    },
     "headed": {
       "type": "boolean",
       "description": "whether to show the browser head"


### PR DESCRIPTION
## Problem

Want to be able to support the playwright `config` option.

## Solution

- Add `config` to executor options

### Useful documentation

- [Contributing guidelines](/marksandspencer/nx-plugins/blob/main/CONTRIBUTING.md)
