### PR TITLE
Display failure logs in more readable format

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mands/nx-plugins",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "description": "Nx plugins by M&S engineering",
   "license": "MIT",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mands/nx-plugins",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "description": "Nx plugins by M&S engineering",
   "license": "MIT",
   "private": false,

--- a/packages/nx-playwright/package.json
+++ b/packages/nx-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mands/nx-playwright",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "license": "MIT",
   "publishConfig": {
     "registry": "https://registry.npmjs.org"

--- a/packages/nx-playwright/package.json
+++ b/packages/nx-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mands/nx-playwright",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "license": "MIT",
   "publishConfig": {
     "registry": "https://registry.npmjs.org"

--- a/packages/nx-playwright/src/executors/playwright-executor/executor.spec.ts
+++ b/packages/nx-playwright/src/executors/playwright-executor/executor.spec.ts
@@ -115,8 +115,9 @@ describe('executor', () => {
       expect(console.info).toHaveBeenCalledWith('Playwright output PLAYWRIGHT_PASS');
     });
 
-    it('fails gracefully when command fails', async () => {
-      const error = new Error('fake error');
+    it('fails gracefully and logs error when command fails', async () => {
+      const error = new Error('fake error') as Error & { stdout: string };
+      error.stdout = '\nRunning 3 tests using 1 worker\n...';
       promisify.mockReturnValueOnce(jest.fn().mockRejectedValueOnce(error));
 
       const { success } = await executor(options, context);
@@ -124,7 +125,7 @@ describe('executor', () => {
       expect(success).toBe(false);
 
       expect(console.error).toHaveBeenCalledTimes(1);
-      expect(console.error).toHaveBeenCalledWith('Unexpected error', error);
+      expect(console.error).toHaveBeenCalledWith(`Playwright errors ${error.stdout}`);
     });
   });
 });

--- a/packages/nx-playwright/src/executors/playwright-executor/executor.spec.ts
+++ b/packages/nx-playwright/src/executors/playwright-executor/executor.spec.ts
@@ -146,7 +146,6 @@ describe('executor', () => {
 
     it('fails gracefully when command fails without stdout or stderr', async () => {
       const error = new Error('fake error');
-
       promisify.mockReturnValueOnce(jest.fn().mockRejectedValueOnce(error));
 
       const { success } = await executor(options, context);

--- a/packages/nx-playwright/src/executors/playwright-executor/executor.spec.ts
+++ b/packages/nx-playwright/src/executors/playwright-executor/executor.spec.ts
@@ -133,7 +133,7 @@ describe('executor', () => {
 
     it('logs error when command fails with stderr', async () => {
       const error = new Error('fake error') as Error & { stderr: string };
-      error.stderr = '\nFake failure message';
+      error.stderr = '\nFailure message';
       promisify.mockReturnValueOnce(jest.fn().mockRejectedValueOnce(error));
 
       const { success } = await executor(options, context);

--- a/packages/nx-playwright/src/executors/playwright-executor/executor.ts
+++ b/packages/nx-playwright/src/executors/playwright-executor/executor.ts
@@ -59,7 +59,12 @@ export default async function executor(
       return stdout.includes(PASS_MARKER);
     })
     .catch((error) => {
-      console.error(`Playwright errors ${error.stdout}`);
+      const message = error.stdout || error.stderr;
+      if (message) {
+        console.error(`Playwright errors ${message}`);
+      } else {
+        console.error('Unexpected error', error);
+      }
       return false;
     });
 

--- a/packages/nx-playwright/src/executors/playwright-executor/executor.ts
+++ b/packages/nx-playwright/src/executors/playwright-executor/executor.ts
@@ -58,7 +58,7 @@ export default async function executor(
       return stdout.includes(PASS_MARKER);
     })
     .catch((error) => {
-      console.error('Unexpected error', error);
+      console.error(`Playwright errors ${error.stdout}`);
       return false;
     });
 


### PR DESCRIPTION
## Problem

When tests fail, logs are hard to read.  For example:

![image](https://user-images.githubusercontent.com/7114281/214829793-12275e45-4427-4904-a5ea-3346f2e4b2c3.png)


## Solution

- Log `error.stdout` instead of entire error:

### Example Result
![image](https://user-images.githubusercontent.com/7114281/214830079-f15ecbb9-b5c2-4e7d-aa77-384f06ca0330.png)

