### PR TITLE
Add support for --project option via --proj to not conflict with nx.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mands/nx-plugins",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "description": "Nx plugins by M&S engineering",
   "license": "MIT",
   "private": false,

--- a/packages/nx-playwright/README.md
+++ b/packages/nx-playwright/README.md
@@ -34,6 +34,7 @@ yarn nx e2e <APP-NAME>-e2e
 `nx-playwright` has some flags that you can utilize at execution time
 
 - `--browser=BROWSER_TYPE`: allowed browser types being `chromium`, `firefox` or `webkit` (or an `all` type to execute against all 3 types)
+- `--proj`: playwright project name to run (NOTE: this is `--project` option in playwright itself, but it conflicts with nx's option)
 - `--config`: configuration file. Defaults to `playwright.config.ts`
 - `--format=FORMAT_TYPE`: this allows values such as `json` or `html`
 - `--headed`: launches the browser in non-headless mode

--- a/packages/nx-playwright/package.json
+++ b/packages/nx-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mands/nx-playwright",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "license": "MIT",
   "publishConfig": {
     "registry": "https://registry.npmjs.org"

--- a/packages/nx-playwright/src/executors/playwright-executor/executor.spec.ts
+++ b/packages/nx-playwright/src/executors/playwright-executor/executor.spec.ts
@@ -54,6 +54,14 @@ describe('executor', () => {
         },
       ],
       [
+        '--headed --project=demo && echo PLAYWRIGHT_PASS',
+        {
+          e2eFolder: 'folder',
+          headed: true,
+          proj: 'demo',
+        },
+      ],
+      [
         '--grep-invert=@tag1 && echo PLAYWRIGHT_PASS',
         {
           e2eFolder: 'folder',

--- a/packages/nx-playwright/src/executors/playwright-executor/executor.ts
+++ b/packages/nx-playwright/src/executors/playwright-executor/executor.ts
@@ -11,6 +11,7 @@ function getFlags(options: PlaywrightExecutorSchema): string {
   const headedOption = options.headed === true ? '--headed' : '';
   const passWithNoTestsOption = options.passWithNoTests === true ? '--pass-with-no-tests' : '';
   const browserOption = options.browser?.length ? `--browser=${options.browser}` : '';
+  const projectOption = options.proj?.length ? `--project=${options.proj}` : '';
   const reporterOption = options.reporter?.length ? `--reporter=${options.reporter}` : '';
   const timeoutOption = options.timeout !== undefined ? `--timeout=${options.timeout}` : '';
   const grepOption = options.grep !== undefined ? `--grep=${options.grep}` : '';
@@ -19,6 +20,7 @@ function getFlags(options: PlaywrightExecutorSchema): string {
 
   const flagStrings = [
     headedOption,
+    projectOption,
     browserOption,
     reporterOption,
     timeoutOption,

--- a/packages/nx-playwright/src/executors/playwright-executor/schema-types.d.ts
+++ b/packages/nx-playwright/src/executors/playwright-executor/schema-types.d.ts
@@ -12,6 +12,7 @@ export interface PlaywrightExecutorSchema {
   reporter?: string;
   browser?: 'chromium' | 'firefox' | 'webkit' | 'all';
   packageRunner?: PackageRunner;
+  proj?: string;
   timeout?: number;
   skipServe?: boolean;
   grep?: string;

--- a/packages/nx-playwright/src/executors/playwright-executor/schema.json
+++ b/packages/nx-playwright/src/executors/playwright-executor/schema.json
@@ -34,6 +34,10 @@
       "description": "path to run tests at",
       "default": "src"
     },
+    "proj": {
+      "type": "string",
+      "description": "playwright project name to run"
+    },
     "skipServe": {
       "type": "boolean",
       "description": "whether to skip starting the server"


### PR DESCRIPTION
## Problem

I want to be able to use Playwright's projects feature, but the `--project` option is being swallowed by nx, ie. running

```
nx e2e demo-e2e --project=smth
```

results in NX error: 

```
Cannot find project 'smth'
```

and the playwright executor is not even reached.

Related to #63 .

## Solution

Initially I wanted to fix this on NX level, by allowing `--project` flag to be passed to executors, but this would result in an unpredictable behavior and conflict with nx project feature itself.

So I propose to have `--proj` option in this library level to avoid any conflicts.
