### PR TITLE
Add `--debug` flag support to executor.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mands/nx-plugins",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Nx plugins by M&S engineering",
   "license": "MIT",
   "private": false,

--- a/packages/nx-playwright/package.json
+++ b/packages/nx-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mands/nx-playwright",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "license": "MIT",
   "publishConfig": {
     "registry": "https://registry.npmjs.org"

--- a/packages/nx-playwright/src/executors/playwright-executor/executor.ts
+++ b/packages/nx-playwright/src/executors/playwright-executor/executor.ts
@@ -14,7 +14,7 @@ function getFlags(options: PlaywrightExecutorSchema) {
   const grepOption = options.grep !== undefined ? `--grep=${options.grep}` : '';
   const grepInvertOption =
     options.grepInvert !== undefined ? `--grep-invert=${options.grepInvert}` : '';
-  const debugOption = options.debug !== undefined ? '--debug' : '';
+  const debugOption = options.debug === true ? '--debug' : '';
 
   return [
     headedOption,

--- a/packages/nx-playwright/src/executors/playwright-executor/executor.ts
+++ b/packages/nx-playwright/src/executors/playwright-executor/executor.ts
@@ -25,7 +25,7 @@ function getFlags(options: PlaywrightExecutorSchema) {
     grepOption,
     grepInvertOption,
     passWithNoTestsOption,
-    debugOption
+    debugOption,
   ];
 }
 

--- a/packages/nx-playwright/src/executors/playwright-executor/executor.ts
+++ b/packages/nx-playwright/src/executors/playwright-executor/executor.ts
@@ -14,6 +14,7 @@ function getFlags(options: PlaywrightExecutorSchema) {
   const grepOption = options.grep !== undefined ? `--grep=${options.grep}` : '';
   const grepInvertOption =
     options.grepInvert !== undefined ? `--grep-invert=${options.grepInvert}` : '';
+  const debugOption = options.debug !== undefined ? '--debug' : '';
 
   return [
     headedOption,
@@ -24,6 +25,7 @@ function getFlags(options: PlaywrightExecutorSchema) {
     grepOption,
     grepInvertOption,
     passWithNoTestsOption,
+    debugOption
   ];
 }
 

--- a/packages/nx-playwright/src/executors/playwright-executor/schema-types.d.ts
+++ b/packages/nx-playwright/src/executors/playwright-executor/schema-types.d.ts
@@ -18,4 +18,5 @@ export interface PlaywrightExecutorSchema {
   grep?: string;
   grepInvert?: string;
   passWithNoTests?: boolean;
+  debug?: boolean;
 }

--- a/packages/nx-playwright/src/executors/playwright-executor/schema.json
+++ b/packages/nx-playwright/src/executors/playwright-executor/schema.json
@@ -44,6 +44,10 @@
     "timeout": {
       "type": "number",
       "description": "timeout for tests"
+    },
+    "debug": {
+      "type": "boolean",
+      "description": "whether to open the Playwright inspector"
     }
   }
 }


### PR DESCRIPTION
## Problem

<sup>The executor currently does not acknowledge the `--debug` flag for `playwright test`.</sup>

## Solution

<sup>Add `--debug` to the list of integrated flags.</sup>
