### PR TITLE
feat: add ui mode option

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mands/nx-plugins",
-  "version": "0.2.7",
+  "version": "0.3.7",
   "description": "Nx plugins by M&S engineering",
   "license": "MIT",
   "private": false,

--- a/packages/nx-playwright/README.md
+++ b/packages/nx-playwright/README.md
@@ -45,6 +45,7 @@ pnpm nx e2e <APP-NAME>-e2e
 - `--timeout=<number>`: adds a timeout for your tests in milliseconds
 - `--grep=<RegExp|Array<RegExp>>`: filter to only run tests with a title matching one of the patterns
 - `--grepInvert=<RegExp|Array<RegExp>>`: filter to only run tests with a title not matching one of the patterns
+- `--ui`: launches the browser in ui mode to explore, run and debug tests (preview)
 
 > **Note** These flags can also be used in `project.json` or `nx.json`
 

--- a/packages/nx-playwright/package.json
+++ b/packages/nx-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mands/nx-playwright",
-  "version": "0.2.7",
+  "version": "0.3.7",
   "license": "MIT",
   "publishConfig": {
     "registry": "https://registry.npmjs.org"

--- a/packages/nx-playwright/src/executors/playwright-executor/executor.spec.ts
+++ b/packages/nx-playwright/src/executors/playwright-executor/executor.spec.ts
@@ -113,6 +113,13 @@ describe('executor', () => {
         e2eFolder: 'folder',
       },
     ],
+    [
+      '--ui',
+      {
+        uiMode: true,
+        e2eFolder: 'folder',
+      },
+    ],
   ])(`runs playwright with options: %s`, async (expected, options) => {
     execMock.mockImplementation((_command, _options, callback) => {
       callback(null, 'passed', '');

--- a/packages/nx-playwright/src/executors/playwright-executor/executor.ts
+++ b/packages/nx-playwright/src/executors/playwright-executor/executor.ts
@@ -15,6 +15,7 @@ function getFlags({
   grep,
   grepInvert,
   updateSnapshots,
+  uiMode,
 }: PlaywrightExecutorSchema) {
   const headedOption = headed === true ? '--headed' : '';
   const passWithNoTestsOption = passWithNoTests === true ? '--pass-with-no-tests' : '';
@@ -27,6 +28,7 @@ function getFlags({
   const debugOption = debug !== undefined && debug ? '--debug' : '';
   const updateSnapshotsOption =
     updateSnapshots !== undefined && updateSnapshots ? '--update-snapshots' : '';
+  const uiModeOption = uiMode !== undefined && uiMode ? '--ui' : '';
 
   return [
     headedOption,
@@ -39,6 +41,7 @@ function getFlags({
     passWithNoTestsOption,
     debugOption,
     updateSnapshotsOption,
+    uiModeOption,
   ];
 }
 

--- a/packages/nx-playwright/src/executors/playwright-executor/schema-types.d.ts
+++ b/packages/nx-playwright/src/executors/playwright-executor/schema-types.d.ts
@@ -18,4 +18,5 @@ export interface PlaywrightExecutorSchema {
   passWithNoTests?: boolean;
   debug?: boolean;
   updateSnapshots?: boolean;
+  uiMode?: boolean;
 }

--- a/packages/nx-playwright/src/executors/playwright-executor/schema.json
+++ b/packages/nx-playwright/src/executors/playwright-executor/schema.json
@@ -52,6 +52,10 @@
     "updateSnapshots": {
       "type": "boolean",
       "description": "whether to update snapshots with actual results instead of comparing them"
+    },
+    "uiMode": {
+      "type": "boolean",
+      "description": "whether to open Playwright UI mode"
     }
   }
 }


### PR DESCRIPTION
## Problem

<sup>(What is this PR for?)</sup>
The new preview `--ui` CLI option is missing.

## Solution

<sup>(What has changed, reasons and any additional resources)</sup>

This pull request add the `--ui`CLI option added with 1.32: https://playwright.dev/docs/release-notes#version-132

### Useful documentation

- [Contributing guidelines](/marksandspencer/nx-plugins/blob/main/CONTRIBUTING.md)
