### PR TITLE
fix: ui-option

### DIFF
--- a/packages/nx-playwright/src/executors/playwright-executor/executor.spec.ts
+++ b/packages/nx-playwright/src/executors/playwright-executor/executor.spec.ts
@@ -116,7 +116,7 @@ describe('executor', () => {
     [
       '--ui',
       {
-        uiMode: true,
+        ui: true,
         e2eFolder: 'folder',
       },
     ],

--- a/packages/nx-playwright/src/executors/playwright-executor/executor.ts
+++ b/packages/nx-playwright/src/executors/playwright-executor/executor.ts
@@ -15,7 +15,7 @@ function getFlags({
   grep,
   grepInvert,
   updateSnapshots,
-  uiMode,
+  ui
 }: PlaywrightExecutorSchema) {
   const headedOption = headed === true ? '--headed' : '';
   const passWithNoTestsOption = passWithNoTests === true ? '--pass-with-no-tests' : '';
@@ -28,7 +28,7 @@ function getFlags({
   const debugOption = debug !== undefined && debug ? '--debug' : '';
   const updateSnapshotsOption =
     updateSnapshots !== undefined && updateSnapshots ? '--update-snapshots' : '';
-  const uiModeOption = uiMode !== undefined && uiMode ? '--ui' : '';
+  const uiOption = ui !== undefined && ui ? '--ui' : '';
 
   return [
     headedOption,
@@ -41,7 +41,7 @@ function getFlags({
     passWithNoTestsOption,
     debugOption,
     updateSnapshotsOption,
-    uiModeOption,
+    uiOption,
   ];
 }
 

--- a/packages/nx-playwright/src/executors/playwright-executor/schema-types.d.ts
+++ b/packages/nx-playwright/src/executors/playwright-executor/schema-types.d.ts
@@ -18,5 +18,5 @@ export interface PlaywrightExecutorSchema {
   passWithNoTests?: boolean;
   debug?: boolean;
   updateSnapshots?: boolean;
-  uiMode?: boolean;
+  ui?: boolean;
 }

--- a/packages/nx-playwright/src/executors/playwright-executor/schema.json
+++ b/packages/nx-playwright/src/executors/playwright-executor/schema.json
@@ -8,7 +8,12 @@
   "type": "object",
   "properties": {
     "browser": {
-      "enum": ["all", "chromium", "firefox", "webkit"],
+      "enum": [
+        "all",
+        "chromium",
+        "firefox",
+        "webkit"
+      ],
       "description": "run on specific browser (all for all)"
     },
     "config": {
@@ -25,7 +30,11 @@
       "description": "type of output reporter"
     },
     "packageRunner": {
-      "enum": ["yarn", "npx", "pnpm"],
+      "enum": [
+        "yarn",
+        "npx",
+        "pnpm"
+      ],
       "description": "package runner to use to run playwright"
     },
     "path": {
@@ -53,7 +62,7 @@
       "type": "boolean",
       "description": "whether to update snapshots with actual results instead of comparing them"
     },
-    "uiMode": {
+    "ui": {
       "type": "boolean",
       "description": "whether to open Playwright UI mode"
     }


### PR DESCRIPTION
## Problem

I couldn't get the new `ui`-flag to work. Seems like a typo, where `uiMode` is expected in the executor

## Solution

I propose to change `uiMode` to `ui` to align with Playwrights API (https://playwright.dev/docs/release-notes#version-132)
We could also possibly keep both to be backwards-compatible if necessary

### Useful documentation

- [Contributing guidelines](/marksandspencer/nx-plugins/blob/main/CONTRIBUTING.md)
