### PR TITLE
Add --includeAxe flag to nx-playwright generator

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mands/nx-plugins",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Nx plugins by M&S engineering",
   "license": "MIT",
   "private": false,

--- a/packages/nx-playwright/README.md
+++ b/packages/nx-playwright/README.md
@@ -34,7 +34,7 @@ pnpm nx e2e <APP-NAME>-e2e
 ### Running accessibility tests
 
 ```sh
-pnpm nx axe <APP-NAME>-e2e
+pnpm nx e2e <APP-NAME>-e2e --configuration=axe
 ```
 
 ## Execution Flags

--- a/packages/nx-playwright/README.md
+++ b/packages/nx-playwright/README.md
@@ -23,10 +23,18 @@ pnpm playwright install --with-deps
 pnpm nx generate @mands/nx-playwright:project <APP-NAME>-e2e --project <APP-NAME>
 ```
 
+Optionally the `--includeAxe` flag can be included to generate [axe-playwright](https://www.npmjs.com/package/axe-playwright) accessibility tests.
+
 ### Running tests
 
 ```sh
 pnpm nx e2e <APP-NAME>-e2e
+```
+
+### Running accessibility tests
+
+```sh
+pnpm nx axe <APP-NAME>-e2e
 ```
 
 ## Execution Flags

--- a/packages/nx-playwright/package.json
+++ b/packages/nx-playwright/package.json
@@ -14,6 +14,7 @@
   "executors": "./executors.json",
   "peerDependencies": {
     "@playwright/test": "^1.32.1",
+    "axe-playwright": "^1.2.3",
     "playwright": "^1.32.1"
   }
 }

--- a/packages/nx-playwright/package.json
+++ b/packages/nx-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mands/nx-playwright",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "license": "MIT",
   "publishConfig": {
     "registry": "https://registry.npmjs.org"

--- a/packages/nx-playwright/src/generators/init/generator.spec.ts
+++ b/packages/nx-playwright/src/generators/init/generator.spec.ts
@@ -1,4 +1,5 @@
 import { addDependenciesToPackageJson, formatFiles, Tree, updateJson } from '@nrwl/devkit';
+import { playwrightAxeVersion } from '../../versions';
 import playwrightInitGenerator, { removePlaywrightDeps } from './generator';
 
 const MOCK_HOST: Tree = {
@@ -50,6 +51,40 @@ describe('generator', () => {
     expect(playwrightInitTask).toBeTruthy();
     expect(addDependenciesToPackageJsonMock).toHaveBeenCalled();
     expect(formatFilesMock).toHaveBeenCalled();
+  });
+
+  it('does not add axe-playwright to package.json when includeAxe option is not present', async () => {
+    updateJsonMock.mockReturnValueOnce(undefined);
+    formatFilesMock.mockResolvedValueOnce(undefined);
+
+    const host = treeFactory();
+
+    await playwrightInitGenerator(host, {});
+
+    expect(addDependenciesToPackageJsonMock).toHaveBeenCalledWith(
+      host,
+      {},
+      expect.objectContaining({
+        'axe-playwright': undefined,
+      }),
+    );
+  });
+
+  it('adds axe-playwright to package.json when includeAxe option is true', async () => {
+    updateJsonMock.mockReturnValueOnce(undefined);
+    formatFilesMock.mockResolvedValueOnce(undefined);
+
+    const host = treeFactory();
+
+    await playwrightInitGenerator(host, { includeAxe: true });
+
+    expect(addDependenciesToPackageJsonMock).toHaveBeenCalledWith(
+      host,
+      {},
+      expect.objectContaining({
+        'axe-playwright': playwrightAxeVersion,
+      }),
+    );
   });
 
   it('remove existing "@mands/nx-playwright" package from package.json', async () => {

--- a/packages/nx-playwright/src/generators/init/generator.ts
+++ b/packages/nx-playwright/src/generators/init/generator.ts
@@ -1,6 +1,6 @@
 import { addDependenciesToPackageJson, formatFiles, Tree, updateJson } from '@nrwl/devkit';
 import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
-import { playwrightTestVersion, playwrightVersion } from '../../versions';
+import { playwrightAxeVersion, playwrightTestVersion, playwrightVersion } from '../../versions';
 import { addGitIgnoreEntry } from './lib/add-git-ignore-entry';
 import { InitGeneratorSchema } from './schema';
 
@@ -14,7 +14,11 @@ export default async function playwrightInitGenerator(host: Tree, options: InitG
   const installTask = addDependenciesToPackageJson(
     host,
     {},
-    { '@playwright/test': playwrightTestVersion, playwright: playwrightVersion },
+    {
+      'axe-playwright': options.includeAxe ? playwrightAxeVersion : undefined,
+      '@playwright/test': playwrightTestVersion,
+      playwright: playwrightVersion,
+    },
   );
 
   if (!options.skipFormat) {

--- a/packages/nx-playwright/src/generators/init/schema.d.ts
+++ b/packages/nx-playwright/src/generators/init/schema.d.ts
@@ -1,3 +1,4 @@
 export interface InitGeneratorSchema {
   skipFormat?: boolean;
+  includeAxe?: boolean;
 }

--- a/packages/nx-playwright/src/generators/project/axe-files/axe-tests/axe-tests.spec.ts__tmpl__
+++ b/packages/nx-playwright/src/generators/project/axe-files/axe-tests/axe-tests.spec.ts__tmpl__
@@ -1,0 +1,14 @@
+import { test } from '@playwright/test';
+import { checkA11y, injectAxe } from 'axe-playwright';
+import config from '../axe.config';
+
+test.describe.parallel('Accessibility tests', () => {
+  for (const path of config.paths) {
+    test(`${path} has no a11y violations`, async ({ page }) => {
+      await page.goto(path);
+      await injectAxe(page);
+
+      await checkA11y(page, 'body', {}, false, 'v2');
+    });
+  }
+});

--- a/packages/nx-playwright/src/generators/project/axe-files/axe.config.ts__tmpl__
+++ b/packages/nx-playwright/src/generators/project/axe-files/axe.config.ts__tmpl__
@@ -1,0 +1,9 @@
+type AxeConfig = {
+  paths: string[];
+};
+
+const config: AxeConfig = {
+  paths: ['/'],
+};
+
+export default config;

--- a/packages/nx-playwright/src/generators/project/generator.spec.ts
+++ b/packages/nx-playwright/src/generators/project/generator.spec.ts
@@ -114,6 +114,64 @@ describe('nx-playwright generator', () => {
       implicitDependencies: ['test-project'],
     });
   });
+
+  it('adds axe target to project.json when includeAxe option is enabled', async () => {
+    const host = createTree();
+
+    await generator(host, {
+      name: 'test-generator',
+      linter: Linter.EsLint,
+      project: 'test-project',
+      includeAxe: true,
+    });
+    const projectJson = readJson(host, 'e2e/test-generator/project.json');
+
+    expect(projectJson.targets).toEqual(
+      expect.objectContaining({
+        axe: {
+          executor: '@mands/nx-playwright:playwright-executor',
+          options: {
+            e2eFolder: 'e2e/test-generator',
+            devServerTarget: 'test-project:serve',
+            path: './axe-tests',
+            skipServe: true,
+          },
+          configurations: {
+            production: {
+              devServerTarget: 'test-project:serve:production',
+            },
+          },
+        },
+      }),
+    );
+  });
+
+  it('generates axe files when includeAxe option is enabled', async () => {
+    const host = createTree();
+
+    await generator(host, {
+      name: 'test-generator',
+      linter: Linter.EsLint,
+      project: 'test-project',
+      includeAxe: true,
+    });
+
+    expect(host.exists('e2e/test-generator/axe.config.ts')).toBe(true);
+    expect(host.exists('e2e/test-generator/axe-tests/axe-tests.spec.ts')).toBe(true);
+  });
+
+  it('does not generate axe files when includeAxe option is not present', async () => {
+    const host = createTree();
+
+    await generator(host, {
+      name: 'test-generator',
+      linter: Linter.EsLint,
+      project: 'test-project',
+    });
+
+    expect(host.exists('e2e/test-generator/axe.config.ts')).toBe(false);
+    expect(host.exists('e2e/test-generator/axe-tests/axe-tests.spec.ts')).toBe(false);
+  });
 });
 
 function createTree() {

--- a/packages/nx-playwright/src/generators/project/generator.spec.ts
+++ b/packages/nx-playwright/src/generators/project/generator.spec.ts
@@ -115,7 +115,7 @@ describe('nx-playwright generator', () => {
     });
   });
 
-  it('adds axe target to project.json when includeAxe option is enabled', async () => {
+  it('adds axe configuration to e2e target in project.json when includeAxe option is enabled', async () => {
     const host = createTree();
 
     await generator(host, {
@@ -126,21 +126,11 @@ describe('nx-playwright generator', () => {
     });
     const projectJson = readJson(host, 'e2e/test-generator/project.json');
 
-    expect(projectJson.targets).toEqual(
+    expect(projectJson.targets.e2e.configurations).toEqual(
       expect.objectContaining({
         axe: {
-          executor: '@mands/nx-playwright:playwright-executor',
-          options: {
-            e2eFolder: 'e2e/test-generator',
-            devServerTarget: 'test-project:serve',
-            path: './axe-tests',
-            skipServe: true,
-          },
-          configurations: {
-            production: {
-              devServerTarget: 'test-project:serve:production',
-            },
-          },
+          path: './axe-tests',
+          skipServe: true,
         },
       }),
     );

--- a/packages/nx-playwright/src/generators/project/generator.ts
+++ b/packages/nx-playwright/src/generators/project/generator.ts
@@ -33,24 +33,6 @@ export default async function (host: Tree, options: NxPlaywrightGeneratorSchema)
     sourceRoot: `${normalizedOptions.projectRoot}/src`,
     projectType: 'application',
     targets: {
-      axe: options.includeAxe
-        ? {
-            executor: '@mands/nx-playwright:playwright-executor',
-            options: {
-              e2eFolder: normalizedOptions.projectRoot,
-              devServerTarget: options.project ? `${options.project}:serve` : undefined,
-              path: './axe-tests',
-              skipServe: true,
-            },
-            configurations: {
-              production: {
-                devServerTarget: options.project
-                  ? `${options.project}:serve:production`
-                  : undefined,
-              },
-            },
-          }
-        : undefined,
       e2e: {
         executor: '@mands/nx-playwright:playwright-executor',
         options: {
@@ -59,6 +41,12 @@ export default async function (host: Tree, options: NxPlaywrightGeneratorSchema)
           packageRunner: options.packageRunner ?? generatorSchema.properties.packageRunner.default,
         },
         configurations: {
+          axe: options.includeAxe
+            ? {
+                path: './axe-tests',
+                skipServe: true,
+              }
+            : undefined,
           production: {
             devServerTarget: options.project ? `${options.project}:serve:production` : undefined,
           },

--- a/packages/nx-playwright/src/generators/project/schema-types.d.ts
+++ b/packages/nx-playwright/src/generators/project/schema-types.d.ts
@@ -9,4 +9,5 @@ export interface NxPlaywrightGeneratorSchema {
   linter: Linter;
   skipFormat?: boolean;
   packageRunner?: PackageRunner;
+  includeAxe?: boolean;
 }

--- a/packages/nx-playwright/src/versions.ts
+++ b/packages/nx-playwright/src/versions.ts
@@ -1,4 +1,5 @@
 import packageJson from '../package.json';
 
+export const playwrightAxeVersion = packageJson.peerDependencies['axe-playwright'];
 export const playwrightVersion = packageJson.peerDependencies.playwright;
 export const playwrightTestVersion = packageJson.peerDependencies['@playwright/test'];


### PR DESCRIPTION
## Problem

This PR adds the ability to generate AXE (accessibility) tests when running the `nx-playwright` generator.

`--includeAxe` flag can be included when running the generator:

```bash
pnpm nx generate @mands/nx-playwright:project <APP-NAME>-e2e --project <APP-NAME> --includeAxe
```

This will result in:

- addition of an `axe` configuration to `e2e` target in `project.json`
- generation of `apps/<APP-NAME>-e2e/axe.config.ts`: where URL paths can be added to be tested for accessibility issues
- generation of `apps/<APP-NAME>-e2e/axe-tests/axe-tests.spec.ts`: where the AXE tests are defined
- addition of `axe-playwright` as a devDependency

### Useful documentation

- [Contributing guidelines](/marksandspencer/nx-plugins/blob/main/CONTRIBUTING.md)
