### PR TITLE
Fix: linting errors introduced in AXE tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mands/nx-plugins",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Nx plugins by M&S engineering",
   "license": "MIT",
   "private": false,

--- a/packages/nx-playwright/package.json
+++ b/packages/nx-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mands/nx-playwright",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "license": "MIT",
   "publishConfig": {
     "registry": "https://registry.npmjs.org"

--- a/packages/nx-playwright/src/generators/project/axe-files/axe-tests/axe-tests.spec.ts__tmpl__
+++ b/packages/nx-playwright/src/generators/project/axe-files/axe-tests/axe-tests.spec.ts__tmpl__
@@ -1,5 +1,6 @@
 import { test } from '@playwright/test';
 import { checkA11y, injectAxe } from 'axe-playwright';
+
 import config from '../axe.config';
 
 test.describe.parallel('Accessibility tests', () => {

--- a/packages/nx-playwright/src/generators/project/generator.spec.ts
+++ b/packages/nx-playwright/src/generators/project/generator.spec.ts
@@ -162,6 +162,59 @@ describe('nx-playwright generator', () => {
     expect(host.exists('e2e/test-generator/axe.config.ts')).toBe(false);
     expect(host.exists('e2e/test-generator/axe-tests/axe-tests.spec.ts')).toBe(false);
   });
+
+  it('generates correct .eslintrc.json', async () => {
+    const host = createTree();
+
+    await generator(host, {
+      name: 'test-generator',
+      linter: Linter.EsLint,
+      project: 'test-project',
+    });
+    const eslintJson = readJson(host, 'e2e/test-generator/.eslintrc.json');
+
+    expect(eslintJson).toEqual({
+      extends: ['../../.eslintrc.json'],
+      ignorePatterns: ['!**/*'],
+      overrides: [
+        {
+          files: ['*.ts', '*.tsx', '*.js', '*.jsx'],
+          rules: { 'jest/no-done-callback': 'off' },
+        },
+        {
+          files: ['*.ts', '*.tsx'],
+          rules: { 'jest/no-done-callback': 'off' },
+        },
+        {
+          files: ['*.js', '*.jsx'],
+          rules: {},
+        },
+      ],
+    });
+  });
+
+  it('adds an override for AXE tests to .eslintrc.json when includeAxe option is present', async () => {
+    const host = createTree();
+
+    await generator(host, {
+      name: 'test-generator',
+      linter: Linter.EsLint,
+      project: 'test-project',
+      includeAxe: true,
+    });
+    const eslintJson = readJson(host, 'e2e/test-generator/.eslintrc.json');
+
+    expect(eslintJson).toEqual({
+      extends: ['../../.eslintrc.json'],
+      ignorePatterns: ['!**/*'],
+      overrides: expect.arrayContaining([
+        {
+          files: ['**/axe-tests/axe-tests.spec.ts'],
+          rules: { 'jest/expect-expect': 'off' },
+        },
+      ]),
+    });
+  });
 });
 
 function createTree() {

--- a/packages/nx-playwright/src/generators/project/lib/add-linting.ts
+++ b/packages/nx-playwright/src/generators/project/lib/add-linting.ts
@@ -26,13 +26,25 @@ export async function addLinting(
       host,
       joinPathFragments(options.projectRoot, '.eslintrc.json'),
       (json: EslintIgnoreFile) => {
-        const overrides = json.overrides.map(({ files, rules }) =>
+        const baseOverrides = json.overrides.map(({ files, rules }) =>
           files.includes('*.ts')
             ? { files, rules: { 'jest/no-done-callback': 'off' } }
             : { files, rules },
         );
 
-        return { ...json, overrides, extends: [...json.extends] };
+        return {
+          ...json,
+          overrides: options.includeAxe
+            ? [
+                ...baseOverrides,
+                {
+                  files: ['**/axe-tests/axe-tests.spec.ts'],
+                  rules: { 'jest/expect-expect': 'off' },
+                },
+              ]
+            : baseOverrides,
+          extends: [...json.extends],
+        };
       },
     );
   }


### PR DESCRIPTION
## Problem

When running the generator with the `--includeAxe` flag there are two linting issues being introduced:

- Imports are not following the standard proposed by [eslint-plugin-simple-import-sort](https://www.npmjs.com/package/eslint-plugin-simple-import-sort)
- AXE tests don't need an `expect` statement but not including any is prompted as a warning

<img width="933" alt="image" src="https://github.com/marksandspencer/nx-plugins/assets/7059673/da2c9ed5-4aa7-4dca-a6a8-a845432c6d46">


## Solution

- Template for AXE tests updated to follow standard import linting rules
- Added `"jest/expect-expect": "off"` override to the generated `.eslintrc.json` file when the `includeAxe` flag is present

### Useful documentation

- [Contributing guidelines](/marksandspencer/nx-plugins/blob/main/CONTRIBUTING.md)
