### PR TITLE
Fixed issues with Nx 17

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -13,11 +13,11 @@ runs:
         PNPM_VERSION=$(jq -r '.engines.pnpm' < package.json | sed -r 's/[>=]+//g')
         echo "value=${PNPM_VERSION}" >> "$GITHUB_OUTPUT"
 
-    - uses: pnpm/action-setup@v2.2.4
+    - uses: pnpm/action-setup@v2.4.0
       with:
         version: ${{ steps.get-pnpm-version.outputs.value }}
 
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v3.8.2
       with:
         node-version: ${{ steps.get-node-version.outputs.value }}
         cache: pnpm

--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -13,11 +13,11 @@ runs:
         PNPM_VERSION=$(jq -r '.engines.pnpm' < package.json | sed -r 's/[>=]+//g')
         echo "value=${PNPM_VERSION}" >> "$GITHUB_OUTPUT"
 
-    - uses: pnpm/action-setup@v2.4.0
+    - uses: pnpm/action-setup@v2.2.4
       with:
         version: ${{ steps.get-pnpm-version.outputs.value }}
 
-    - uses: actions/setup-node@v3.8.2
+    - uses: actions/setup-node@v3
       with:
         node-version: ${{ steps.get-node-version.outputs.value }}
         cache: pnpm

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -69,6 +69,7 @@ jobs:
           pnpm create nx-workspace \
             --name=$NX_WORKSPACE --appName=$NX_APP \
             --preset=next --style=@emotion/styled \
+            --e2eTestRunner=playwright --nextAppDir=false \
             --nxCloud=false --interactive=false < /dev/null
 
           pushd $NX_WORKSPACE

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mands/nx-plugins",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Nx plugins by M&S engineering",
   "license": "MIT",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "npm": "please-use-pnpm",
     "yarn": "please-use-pnpm",
     "node": ">=16",
-    "pnpm": ">=7.28"
+    "pnpm": ">=8.9"
   },
   "dependencies": {
     "glob": "^7.2.0"

--- a/packages/nx-playwright/package.json
+++ b/packages/nx-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mands/nx-playwright",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "license": "MIT",
   "publishConfig": {
     "registry": "https://registry.npmjs.org"

--- a/packages/nx-playwright/src/generators/init/generator.spec.ts
+++ b/packages/nx-playwright/src/generators/init/generator.spec.ts
@@ -17,6 +17,7 @@ const MOCK_HOST: Tree = {
 const treeFactory = () => MOCK_HOST;
 
 jest.mock('@nx/devkit', () => ({
+  ...jest.requireActual('@nx/devkit'),
   addDependenciesToPackageJson: jest.fn(),
   updateJson: jest.fn(),
   formatFiles: jest.fn(),
@@ -64,8 +65,8 @@ describe('generator', () => {
     expect(addDependenciesToPackageJsonMock).toHaveBeenCalledWith(
       host,
       {},
-      expect.objectContaining({
-        'axe-playwright': undefined,
+      expect.not.objectContaining({
+        'axe-playwright': expect.anything(),
       }),
     );
   });

--- a/packages/nx-playwright/src/generators/init/generator.ts
+++ b/packages/nx-playwright/src/generators/init/generator.ts
@@ -1,5 +1,10 @@
-import { addDependenciesToPackageJson, formatFiles, Tree, updateJson } from '@nx/devkit';
-import { runTasksInSerial } from '@nx/workspace/src/utilities/run-tasks-in-serial';
+import {
+  addDependenciesToPackageJson,
+  formatFiles,
+  runTasksInSerial,
+  Tree,
+  updateJson,
+} from '@nx/devkit';
 import { playwrightAxeVersion, playwrightTestVersion, playwrightVersion } from '../../versions';
 import { addGitIgnoreEntry } from './lib/add-git-ignore-entry';
 import { InitGeneratorSchema } from './schema';
@@ -15,9 +20,9 @@ export default async function playwrightInitGenerator(host: Tree, options: InitG
     host,
     {},
     {
-      'axe-playwright': options.includeAxe ? playwrightAxeVersion : undefined,
       '@playwright/test': playwrightTestVersion,
       playwright: playwrightVersion,
+      ...(options.includeAxe ? { 'axe-playwright': playwrightAxeVersion } : {}),
     },
   );
 

--- a/packages/nx-playwright/src/generators/project/generator.ts
+++ b/packages/nx-playwright/src/generators/project/generator.ts
@@ -5,9 +5,9 @@ import {
   getProjects,
   names,
   offsetFromRoot,
+  runTasksInSerial,
   Tree,
 } from '@nx/devkit';
-import { runTasksInSerial } from '@nx/workspace/src/utilities/run-tasks-in-serial';
 import { existsSync } from 'fs';
 import * as path from 'path';
 import playwrightInitGenerator from '../init/generator';

--- a/packages/nx-playwright/src/generators/project/lib/add-linting.ts
+++ b/packages/nx-playwright/src/generators/project/lib/add-linting.ts
@@ -1,6 +1,11 @@
-import { GeneratorCallback, joinPathFragments, Tree, updateJson } from '@nx/devkit';
+import {
+  GeneratorCallback,
+  joinPathFragments,
+  runTasksInSerial,
+  Tree,
+  updateJson,
+} from '@nx/devkit';
 import { Linter, lintProjectGenerator } from '@nx/linter';
-import { runTasksInSerial } from '@nx/workspace/src/utilities/run-tasks-in-serial';
 import { NxPlaywrightGeneratorNormalizedSchema } from './normalize-options';
 
 type EslintIgnoreFile = {


### PR DESCRIPTION
## Problem

In Nx 17 `runTasksInSerial` is no longer exported from `@nx/workspace` and instead it must be imported from `@nx/devkit`.

There is also an issue with `addDependenciesToPackageJson` that arises when a project using Nx 17 omits the `--includeAxe` flag when calling the `nx-playwright` generator. Looks like the `undefined` value is no longer supported.

## Solution

- All `runTasksInSerial` imports now come from `@nx/devkit`
- `addDependenciesToPackageJson` call refactored so the `axe-playwright` is omitted instead of  set to `undefined` when `--includeAxe` flag is missing
-  Bumped `pnpm` to `>= 8.9` in the engines section because CI was picking `Node v20` and `pnpm v7.x.x` which resulted in a failed `prepare` step
- Added `--e2eTestRunner=playwright` and  `--nextAppDir=false` flags to the "Test plugin" step in the PR validation as the `--interactive=false` option is not enough to suppress those two prompts

### Useful documentation

- [Contributing guidelines](/marksandspencer/nx-plugins/blob/main/CONTRIBUTING.md)
