### PR TITLE
Add use of NODE_AUTH_TOKEN when releasing

### DIFF
--- a/.github/actions/get-node-version/action.yml
+++ b/.github/actions/get-node-version/action.yml
@@ -1,5 +1,5 @@
-name: 'Get node version'
-description: 'Read node version defined in package.json'
+name: Get node version
+description: Read node version defined in package.json
 
 outputs:
   value:

--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -1,3 +1,6 @@
+name: Prepare
+description: Installs dependencies
+
 runs:
   using: composite
   steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,7 +2,7 @@ name: PR validation
 
 on:
   pull_request:
-    types: [ready_for_review, opened, synchronize, reopened, push]
+    types: [ready_for_review, opened, synchronize, reopened, edited]
     branches:
       - main
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,11 +18,14 @@ jobs:
         run: pnpm nx build nx-playwright
 
       - name: Release
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
         run: |
           cd dist/packages/nx-playwright
           echo "scope=@mands" > .npmrc
           echo "@mands:registry=https://registry.npmjs.org/" >> .npmrc
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> .npmrc
+          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> .npmrc
           pnpm publish --access=public
 
           VERSION=$(cat package.json | grep version | head -1 | awk -F: '{ print $2 }' | sed 's/[",]//g')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ jobs:
   build:
     name: Build and publish
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4.2.2
 
@@ -22,15 +25,18 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
         run: |
+          set -x
           cd dist/packages/nx-playwright
-          echo "scope=@mands" > .npmrc
-          echo "@mands:registry=https://registry.npmjs.org/" >> .npmrc
-          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> .npmrc
+          {
+            echo "scope=@mands"
+            echo "@mands:registry=https://registry.npmjs.org/"
+            echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}"
+          } > .npmrc
           pnpm publish --access=public
 
-          VERSION=$(cat package.json | grep version | head -1 | awk -F: '{ print $2 }' | sed 's/[",]//g')
+          VERSION=$(node --print "require('./package.json').version")
           echo "Tagging version $VERSION"
           git config user.name release-bot
           git config user.email release-bot@mnscorp.net
-          git tag -a $VERSION -m "Version ${VERSION}"
-          git push origin $VERSION
+          git tag -a "${VERSION}" -m "Version ${VERSION}"
+          git push origin "${VERSION}"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mands/nx-plugins",
-  "version": "0.7.0-beta-3",
+  "version": "0.7.0-beta-4",
   "description": "Nx plugins by M&S engineering",
   "license": "MIT",
   "private": false,

--- a/packages/nx-playwright/package.json
+++ b/packages/nx-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mands/nx-playwright",
-  "version": "0.7.0-beta-3",
+  "version": "0.7.0-beta-4",
   "license": "MIT",
   "publishConfig": {
     "registry": "https://registry.npmjs.org"


### PR DESCRIPTION
## Problem

Trying to fix the issue where releasing a new version fails.

## Solution

- release workflow:
  - added permissions
  - added `NODE_AUTH_TOKEN` env var
  - tidied up scripting
- did some other tidying up

### Useful documentation

- [Contributing guidelines](/marksandspencer/nx-plugins/blob/main/CONTRIBUTING.md)
