### PR TITLE
Trigger release 0.7.0-beta-6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     name: Build and publish
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       id-token: write
     steps:
       - uses: actions/checkout@v4.2.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mands/nx-plugins",
-  "version": "0.7.0-beta-5",
+  "version": "0.7.0-beta-6",
   "description": "Nx plugins by M&S engineering",
   "license": "MIT",
   "private": false,

--- a/packages/nx-playwright/package.json
+++ b/packages/nx-playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mands/nx-playwright",
-  "version": "0.7.0-beta-5",
+  "version": "0.7.0-beta-6",
   "license": "MIT",
   "publishConfig": {
     "registry": "https://registry.npmjs.org"


### PR DESCRIPTION
## Problem

Previous releases have failed – we believe this is because of incorrect permissions specified in the release workflow.

## Solution

Change `contents: read` to `contents: write` in the release workflow.

### Useful documentation

- [Contributing guidelines](/marksandspencer/nx-plugins/blob/main/CONTRIBUTING.md)
